### PR TITLE
Provide a slice with per-packet TTLs in the statistics

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -66,7 +66,7 @@ func main() {
 
 	pinger.OnRecv = func(pkt *ping.Packet) {
 		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
+			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.TTL)
 	}
 	pinger.OnFinish = func(stats *ping.Statistics) {
 		fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)

--- a/ping.go
+++ b/ping.go
@@ -127,6 +127,9 @@ type Pinger struct {
 	// rtts is all of the Rtts
 	rtts []time.Duration
 
+	// ttls is all of the Ttls
+	ttls []int
+
 	// OnRecv is called when Pinger receives and processes a packet
 	OnRecv func(*Packet)
 
@@ -215,6 +218,9 @@ type Statistics struct {
 	// StdDevRtt is the standard deviation of the round-trip times sent via
 	// this pinger.
 	StdDevRtt time.Duration
+
+	// Ttts is all of the TTLs sent via this pinger.
+	Ttls []int
 }
 
 // SetIPAddr sets the ip address of the target host.
@@ -381,6 +387,7 @@ func (p *Pinger) Statistics() *Statistics {
 		IPAddr:      p.ipaddr,
 		MaxRtt:      max,
 		MinRtt:      min,
+		Ttls:        p.ttls,
 	}
 	if len(p.rtts) > 0 {
 		s.AvgRtt = total / time.Duration(len(p.rtts))
@@ -505,6 +512,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 	}
 
 	p.rtts = append(p.rtts, outPkt.Rtt)
+	p.ttls = append(p.ttls, outPkt.TTL)
 	handler := p.OnRecv
 	if handler != nil {
 		handler(outPkt)

--- a/ping.go
+++ b/ping.go
@@ -179,7 +179,7 @@ type Packet struct {
 	Seq int
 
 	// TTL is the Time To Live on the packet.
-	Ttl int
+	TTL int
 }
 
 // Statistics represent the stats of a currently running or finished
@@ -470,7 +470,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 		Nbytes: recv.nbytes,
 		IPAddr: p.ipaddr,
 		Addr:   p.addr,
-		Ttl:    recv.ttl,
+		TTL:    recv.ttl,
 	}
 
 	switch pkt := m.Body.(type) {


### PR DESCRIPTION
A couple of commits:
 - Fix linitng for TTL: rename Ttl to TTL so that the linter does not complain
 - Provide TTLs in the stats: the real thing, to add a slice in Statistics() with the TTLs