### PR TITLE
Fixed lockup in recvICMP code.

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -434,7 +434,12 @@ func (p *Pinger) recvICMP(
 				}
 			}
 
-			recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}
+			select {
+			case recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}:
+
+			case <-p.done:
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
I noticed lockup in

recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}:

when there are multiple CPU cores available and there are multiple pings running in parallel.