### PR TITLE
Return error from Run()

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -82,5 +82,8 @@ func main() {
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())
-	pinger.Run()
+	err = pinger.Run()
+	if err != nil {
+		fmt.Printf("Failed to ping target host: %s", err)
+	}
 }

--- a/ping.go
+++ b/ping.go
@@ -326,6 +326,7 @@ func (p *Pinger) Run() error {
 	recv := make(chan *packet, 5)
 	defer close(recv)
 	wg.Add(1)
+	//nolint:errcheck
 	go p.recvICMP(conn, recv, &wg)
 
 	err = p.sendICMP(conn)


### PR DESCRIPTION
The current situation is the error messages are being printed with `fmt.Printf` or `fmt.Println`. In some cases, the caller might want to handle these errors by themselves without printing them.

This PR fixes the issue.