### PR TITLE
Bugfix: NewPinger shoud fail when ip is empty.

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -46,6 +46,7 @@ package ping
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -230,6 +231,9 @@ func (p *Pinger) IPAddr() *net.IPAddr {
 
 // Resolve does the DNS lookup for the Pinger address and sets IP protocol.
 func (p *Pinger) Resolve() error {
+	if len(p.addr) == 0 {
+		return errors.New("addr cannot be empty")
+	}
 	ipaddr, err := net.ResolveIPAddr(p.network, p.addr)
 	if err != nil {
 		return err

--- a/ping_test.go
+++ b/ping_test.go
@@ -360,7 +360,7 @@ func TestSetIPAddr(t *testing.T) {
 
 func TestEmptyIPAddr(t *testing.T) {
 	_, err := NewPinger("")
-	AssertError(t, err, "")
+	AssertError(t, err, "empty pinger did not return an error")
 }
 
 func TestStatisticsSunny(t *testing.T) {

--- a/ping_test.go
+++ b/ping_test.go
@@ -358,6 +358,11 @@ func TestSetIPAddr(t *testing.T) {
 	AssertEqualStrings(t, googleaddr.String(), p.Addr())
 }
 
+func TestEmptyIPAddr(t *testing.T) {
+	_, err := NewPinger("")
+	AssertError(t, err, "")
+}
+
 func TestStatisticsSunny(t *testing.T) {
 	// Create a localhost ipv4 pinger
 	p := New("localhost")


### PR DESCRIPTION
When NewPinger with empty ip addr,  ping.Run will hangs forever.

for example
```
func main()  {
	pinger, err := NewPinger("")
	pinger.Run()
}
```

this pr check if addr is empty at first, and return error when it is empty.