### PR TITLE
add timeout for writing channel

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -434,7 +434,10 @@ func (p *Pinger) recvICMP(
 				}
 			}
 
-			recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}
+			select {
+			case recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}:
+			case <-time.After(time.Millisecond * 10):
+			}
 		}
 	}
 }


### PR DESCRIPTION
fix blocked channel bug

I found pinger.Run() always block forever

```
curl http://127.0.0.1:8000/debug/pprof/goroutine?debug=1
goroutine profile: total 44
16 @ 0x1038820 0x1006f9d 0x1006d65 0x14de201 0x10678d1
#	0x14de200	github.com/sparrc/go-ping.(*Pinger).recvICMP+0x1f0	/Users/light/go/pkg/mod/github.com/sparrc/go-ping@v0.0.0-20190613174326-4e5b6552494c/ping.go:437

16 @ 0x1038820 0x10491c0 0x10491ab 0x1048e12 0x10752f4 0x14ddadf 0x14e0555 0x14e054c 0x14e0e5c 0x10678d1
#	0x1048e11	sync.runtime_Semacquire+0x41					/usr/local/go/src/runtime/sema.go:56
#	0x10752f3	sync.(*WaitGroup).Wait+0x63					/usr/local/go/src/sync/waitgroup.go:130
#	0x14ddade	github.com/sparrc/go-ping.(*Pinger).run+0x66e			/Users/light/go/pkg/mod/github.com/sparrc/go-ping@v0.0.0-20190613174326-4e5b6552494c/ping.go:320
#	0x14e0554	github.com/sparrc/go-ping.(*Pinger).Run+0x64			/Users/light/go/pkg/mod/github.com/sparrc/go-ping@v0.0.0-20190613174326-4e5b6552494c/ping.go:278
```