### PR TITLE
Add goreleaser build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,46 @@
-version: 2.0
+---
+executors:
+  golang:
+    docker:
+    - image: cimg/go:1.15
+
+version: 2.1
 jobs:
   build:
-    docker:
-      - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/go-ping/ping
+    executor: golang
     steps:
       - checkout
-      - run:
-          name: Build and run some basic tests
-          command: |
-            go get ./...
-            go vet ./...
-            go test ./... -cover -race
-            go build -race -o ping_linux ./cmd/ping/ping.go
-            sudo ./ping_linux --privileged -c 2 www.google.com
-            sudo ./ping_linux --privileged -c 3 -i 200ms www.google.com
-            sudo ./ping_linux --privileged -c 10 -i 100ms -t 1s www.google.com
-            GOOS=darwin go build -o ping_darwin ./cmd/ping/ping.go
+      - run: go mod download
+      - run: go vet ./...
+      - run: go test ./... -cover -race
+      - run: go build -race ./cmd/ping
+      - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh
+      - run: goreleaser release --skip-publish --snapshot
       - store_artifacts:
-          path: ./ping_linux
-      - store_artifacts:
-          path: ./ping_darwin
+          path: dist
+
+  release:
+    executor: golang
+
+    steps:
+    - checkout
+    - run: go mod download
+    - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh
+    - run: goreleaser release
+
+workflows:
+  version: 2
+  stuff:
+    jobs:
+    - build:
+        filters:
+          tags:
+            only: /.*/
+    - release:
+        requires:
+        - build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /ping
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+project_name: ping
+before:
+  hooks:
+  - go mod download
+builds:
+- binary: ping
+  dir: cmd/ping
+  goarch:
+  - amd64
+  - arm
+  - arm64
+  goarm:
+  - 6
+  - 7
+  goos:
+  - darwin
+  - freebsd
+  - linux
+  - windows
+archives:
+- files:
+  - LICENSE
+  - README.md
+  format_overrides:
+  - goos: windows
+    format: zip
+  wrap_in_directory: true
+# TODO: Decide if we want packages (name conflcits with /bin/ping?)
+# nfpms:
+#   homepage: https://github.com/go-ping/ping
+#   maintainer: 'Go Ping Maintainers <go-ping@example.com>'
+#   description: Ping written in Go.
+#   license: MIT
+#   formats:
+#   - deb
+#   - rpm
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-{{ .ShortCommit }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
* Add goreleaser config.
* Update .gitignore to skip build output.
* Update CircleCI to Go 1.15 with new optimized image[0].
* Add release workflow step.

[0]: https://circleci.com/docs/2.0/circleci-images/#next-gen-circleci-images

Signed-off-by: Ben Kochie <superq@gmail.com>