### PR TITLE
Rename acronym fields

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -70,18 +70,18 @@ func main() {
 
 	pinger.OnRecv = func(pkt *ping.Packet) {
 		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
+			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.RTT, pkt.TTL)
 	}
 	pinger.OnDuplicateRecv = func(pkt *ping.Packet) {
 		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
+			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.RTT, pkt.TTL)
 	}
 	pinger.OnFinish = func(stats *ping.Statistics) {
 		fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
 		fmt.Printf("%d packets transmitted, %d packets received, %d duplicates, %v%% packet loss\n",
 			stats.PacketsSent, stats.PacketsRecv, stats.PacketsRecvDuplicates, stats.PacketLoss)
 		fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
-			stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
+			stats.MinRTT, stats.AvgRTT, stats.MaxRTT, stats.StdDevRTT)
 	}
 
 	pinger.Count = *count

--- a/ping_test.go
+++ b/ping_test.go
@@ -373,16 +373,16 @@ func TestStatisticsSunny(t *testing.T) {
 	AssertEqualStrings(t, "localhost", p.Addr())
 
 	p.PacketsSent = 10
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
 
 	stats := p.Statistics()
 	if stats.PacketsRecv != 10 {
@@ -394,17 +394,17 @@ func TestStatisticsSunny(t *testing.T) {
 	if stats.PacketLoss != 0 {
 		t.Errorf("Expected %v, got %v", 0, stats.PacketLoss)
 	}
-	if stats.MinRtt != time.Duration(1000) {
-		t.Errorf("Expected %v, got %v", time.Duration(1000), stats.MinRtt)
+	if stats.MinRTT != time.Duration(1000) {
+		t.Errorf("Expected %v, got %v", time.Duration(1000), stats.MinRTT)
 	}
-	if stats.MaxRtt != time.Duration(1000) {
-		t.Errorf("Expected %v, got %v", time.Duration(1000), stats.MaxRtt)
+	if stats.MaxRTT != time.Duration(1000) {
+		t.Errorf("Expected %v, got %v", time.Duration(1000), stats.MaxRTT)
 	}
-	if stats.AvgRtt != time.Duration(1000) {
-		t.Errorf("Expected %v, got %v", time.Duration(1000), stats.AvgRtt)
+	if stats.AvgRTT != time.Duration(1000) {
+		t.Errorf("Expected %v, got %v", time.Duration(1000), stats.AvgRTT)
 	}
-	if stats.StdDevRtt != time.Duration(0) {
-		t.Errorf("Expected %v, got %v", time.Duration(0), stats.StdDevRtt)
+	if stats.StdDevRTT != time.Duration(0) {
+		t.Errorf("Expected %v, got %v", time.Duration(0), stats.StdDevRTT)
 	}
 }
 
@@ -416,16 +416,16 @@ func TestStatisticsLossy(t *testing.T) {
 	AssertEqualStrings(t, "localhost", p.Addr())
 
 	p.PacketsSent = 20
-	p.updateStatistics(&Packet{Rtt: time.Duration(10)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(10000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(800)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(40)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(100000)})
-	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(10)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(10000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(800)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(40)})
+	p.updateStatistics(&Packet{RTT: time.Duration(100000)})
+	p.updateStatistics(&Packet{RTT: time.Duration(1000)})
 
 	stats := p.Statistics()
 	if stats.PacketsRecv != 10 {
@@ -437,17 +437,17 @@ func TestStatisticsLossy(t *testing.T) {
 	if stats.PacketLoss != 50 {
 		t.Errorf("Expected %v, got %v", 50, stats.PacketLoss)
 	}
-	if stats.MinRtt != time.Duration(10) {
-		t.Errorf("Expected %v, got %v", time.Duration(10), stats.MinRtt)
+	if stats.MinRTT != time.Duration(10) {
+		t.Errorf("Expected %v, got %v", time.Duration(10), stats.MinRTT)
 	}
-	if stats.MaxRtt != time.Duration(100000) {
-		t.Errorf("Expected %v, got %v", time.Duration(100000), stats.MaxRtt)
+	if stats.MaxRTT != time.Duration(100000) {
+		t.Errorf("Expected %v, got %v", time.Duration(100000), stats.MaxRTT)
 	}
-	if stats.AvgRtt != time.Duration(11585) {
-		t.Errorf("Expected %v, got %v", time.Duration(11585), stats.AvgRtt)
+	if stats.AvgRTT != time.Duration(11585) {
+		t.Errorf("Expected %v, got %v", time.Duration(11585), stats.AvgRTT)
 	}
-	if stats.StdDevRtt != time.Duration(29603) {
-		t.Errorf("Expected %v, got %v", time.Duration(29603), stats.StdDevRtt)
+	if stats.StdDevRTT != time.Duration(29603) {
+		t.Errorf("Expected %v, got %v", time.Duration(29603), stats.StdDevRTT)
 	}
 }
 


### PR DESCRIPTION
Rename `Rtt` and `Ttl` to their respective all-caps names to follow Go
variable naming conventions for acronyms.
* Fix up golint for `Stop()` method.

Signed-off-by: Ben Kochie <superq@gmail.com>