### PR TITLE
Fix `recvICMP` return arguments

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -473,7 +473,7 @@ func (p *Pinger) recvICMP(
 
 			select {
 			case <-p.done:
-				return
+				return nil
 			case recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}:
 			}
 		}


### PR DESCRIPTION
The `Pinger.recvICMP()` method should return `nil` instead of returning nothing. The current return statement causes issues when attempting to `go get` this package.

Running:
```
go get github.com/go-ping/ping
```

Causes the following error:
```
# github.com/go-ping/ping
../../../go/pkg/mod/github.com/go-ping/ping@v0.0.0-20201001152913-70ede2ab323b/ping.go:476:5: not enough arguments to return
	have ()
	want (error)
```