### PR TITLE
Ignore control message errors on Windows

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -51,6 +51,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -312,14 +313,14 @@ func (p *Pinger) Run() error {
 		if conn, err = p.listen(ipv4Proto[p.protocol]); err != nil {
 			return err
 		}
-		if err = conn.IPv4PacketConn().SetControlMessage(ipv4.FlagTTL, true); err != nil {
+		if err = conn.IPv4PacketConn().SetControlMessage(ipv4.FlagTTL, true); runtime.GOOS != "windows" && err != nil {
 			return err
 		}
 	} else {
 		if conn, err = p.listen(ipv6Proto[p.protocol]); err != nil {
 			return err
 		}
-		if err = conn.IPv6PacketConn().SetControlMessage(ipv6.FlagHopLimit, true); err != nil {
+		if err = conn.IPv6PacketConn().SetControlMessage(ipv6.FlagHopLimit, true); runtime.GOOS != "windows" && err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
On Windows, the Go `x/net/ipv4` and `x/net/ipv6` packages do not implement the necessary control message functionality for us to access packet TTLs (see [here](https://pkg.go.dev/golang.org/x/net/ipv4#pkg-note-BUG) and [here](https://pkg.go.dev/golang.org/x/net/ipv6#pkg-note-BUG)). This PR ignores any control message errors that are returned by the `SetControlMessage` function if the Go runtime is compiled targeting Windows.

This fixes issue #105.