### PR TITLE
Document that Run() returns errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ if err != nil {
 	panic(err)
 }
 pinger.Count = 3
-err = pinger.Run() // blocks until finished
+err = pinger.Run() // Blocks until finished.
 if err != nil {
 	panic(err)
 }
@@ -28,7 +28,7 @@ if err != nil {
 	panic(err)
 }
 
-// listen for Ctrl-C
+// Listen for Ctrl-C.
 c := make(chan os.Signal, 1)
 signal.Notify(c, os.Interrupt)
 go func() {

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Here is a very simple example that sends and receives three packets:
 ```go
 pinger, err := ping.NewPinger("www.google.com")
 if err != nil {
-        panic(err)
+	panic(err)
 }
 pinger.Count = 3
-pinger.Run() // blocks until finished
+err = pinger.Run() // blocks until finished
+if err != nil {
+	panic(err)
+}
 stats := pinger.Statistics() // get send/receive/rtt stats
 ```
 
@@ -22,10 +25,10 @@ Here is an example that emulates the traditional UNIX ping command:
 ```go
 pinger, err := ping.NewPinger("www.google.com")
 if err != nil {
-        panic(err)
+	panic(err)
 }
 
-// listen for ctrl-C signal
+// listen for Ctrl-C
 c := make(chan os.Signal, 1)
 signal.Notify(c, os.Interrupt)
 go func() {
@@ -35,19 +38,23 @@ go func() {
 }()
 
 pinger.OnRecv = func(pkt *ping.Packet) {
-        fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v\n",
-                pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt)
+	fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v\n",
+		pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt)
 }
+
 pinger.OnFinish = func(stats *ping.Statistics) {
-        fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
-        fmt.Printf("%d packets transmitted, %d packets received, %v%% packet loss\n",
-                stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
-        fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
-                stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
+	fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
+	fmt.Printf("%d packets transmitted, %d packets received, %v%% packet loss\n",
+		stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
+	fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
+		stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 }
 
 fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())
-pinger.Run()
+err = pinger.Run()
+if err != nil {
+	panic(err)
+}
 ```
 
 It sends ICMP Echo Request packet(s) and waits for an Echo Reply in

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Circle CI](https://circleci.com/gh/go-ping/ping.svg?style=svg)](https://circleci.com/gh/go-ping/ping)
 
 A simple but powerful ICMP echo (ping) library for Go, inspired by
-[go-fastping](https://github.com/tatsushid/go-fastping)
+[go-fastping](https://github.com/tatsushid/go-fastping).
 
 Here is a very simple example that sends and receives three packets:
 
@@ -62,7 +62,7 @@ response. If it receives a response, it calls the `OnRecv` callback.
 When it's finished, it calls the `OnFinish` callback.
 
 For a full ping example, see
-[cmd/ping/ping.go](https://github.com/go-ping/ping/blob/master/cmd/ping/ping.go)
+[cmd/ping/ping.go](https://github.com/go-ping/ping/blob/master/cmd/ping/ping.go).
 
 ## Installation
 

--- a/ping.go
+++ b/ping.go
@@ -1,25 +1,32 @@
-// Package ping is an ICMP ping library seeking to emulate the unix "ping"
-// command.
+// Package ping is a simple but powerful ICMP echo (ping) library.
 //
-// Here is a very simple example that sends & receives 3 packets:
+// Here is a very simple example that sends and receives three packets:
 //
 //	pinger, err := ping.NewPinger("www.google.com")
 //	if err != nil {
 //		panic(err)
 //	}
-//
 //	pinger.Count = 3
-//	pinger.Run() // blocks until finished
+//	err = pinger.Run() // blocks until finished
+//	if err != nil {
+//		panic(err)
+//	}
 //	stats := pinger.Statistics() // get send/receive/rtt stats
 //
-// Here is an example that emulates the unix ping command:
+// Here is an example that emulates the traditional UNIX ping command:
 //
 //	pinger, err := ping.NewPinger("www.google.com")
 //	if err != nil {
-//		fmt.Printf("ERROR: %s\n", err.Error())
-//		return
+//		panic(err)
 //	}
-//
+//	// listen for Ctrl-C
+//	c := make(chan os.Signal, 1)
+//	signal.Notify(c, os.Interrupt)
+//	go func() {
+//		for _ = range c {
+//			pinger.Stop()
+//		}
+//	}()
 //	pinger.OnRecv = func(pkt *ping.Packet) {
 //		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v\n",
 //			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt)
@@ -31,13 +38,15 @@
 //		fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
 //			stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 //	}
-//
 //	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())
-//	pinger.Run()
+//	err = pinger.Run()
+//	if err != nil {
+//		panic(err)
+//	}
 //
-// It sends ICMP packet(s) and waits for a response. If it receives a response,
-// it calls the "receive" callback. When it's finished, it calls the "finish"
-// callback.
+// It sends ICMP Echo Request packet(s) and waits for an Echo Reply in response.
+// If it receives a response, it calls the OnRecv callback. When it's finished,
+// it calls the OnFinish callback.
 //
 // For a full ping example, see "cmd/ping/ping.go".
 //

--- a/ping.go
+++ b/ping.go
@@ -19,7 +19,7 @@
 //	if err != nil {
 //		panic(err)
 //	}
-//	// listen for Ctrl-C
+//	// Listen for Ctrl-C.
 //	c := make(chan os.Signal, 1)
 //	signal.Notify(c, os.Interrupt)
 //	go func() {


### PR DESCRIPTION
#81 changed `pinger.Run()` so that it returned an error but didn't update the documentation in the README or the source code itself. This PR addresses that and also a few other bits of doc-related housekeeping.