### PR TITLE
Add an OnSend handler.

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -124,6 +124,9 @@ type Pinger struct {
 	// rtts is all of the Rtts
 	rtts []time.Duration
 
+	// OnSend is called when Pinger sends a packet
+	OnSend func(*Packet)
+
 	// OnRecv is called when Pinger receives and processes a packet
 	OnRecv func(*Packet)
 
@@ -587,6 +590,17 @@ func (p *Pinger) sendICMP(conn *icmp.PacketConn) error {
 		}
 		p.PacketsSent++
 		p.sequence++
+
+		handler := p.OnSend
+		if handler != nil {
+			outPkt := &Packet{
+				Nbytes: len(msgBytes),
+				IPAddr: p.ipaddr,
+				Addr:   p.addr,
+				Seq:    p.sequence - 1,
+			}
+			handler(outPkt)
+		}
 		break
 	}
 

--- a/ping.go
+++ b/ping.go
@@ -588,19 +588,19 @@ func (p *Pinger) sendICMP(conn *icmp.PacketConn) error {
 				}
 			}
 		}
-		p.PacketsSent++
-		p.sequence++
-
 		handler := p.OnSend
 		if handler != nil {
 			outPkt := &Packet{
 				Nbytes: len(msgBytes),
 				IPAddr: p.ipaddr,
 				Addr:   p.addr,
-				Seq:    p.sequence - 1,
+				Seq:    p.sequence,
 			}
 			handler(outPkt)
 		}
+
+		p.PacketsSent++
+		p.sequence++
 		break
 	}
 


### PR DESCRIPTION
Similar to the OnReceive handler but called when a packet is sent. Reuses the Packet type, but does not set Ttl or Rtt.

This was originally accidentally included in PR 104. Now seperated out.