### PR TITLE
Add option not to store all received rtts.

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -121,6 +121,10 @@ type Pinger struct {
 	// Number of packets received
 	PacketsRecv int
 
+	// If true, keep a record of rtts of all received packets.
+	// Set to false to avoid memory bloat for long running pings.
+	RecordRtts bool
+
 	// rtts is all of the Rtts
 	rtts []time.Duration
 
@@ -533,7 +537,9 @@ func (p *Pinger) processPacket(recv *packet) error {
 		return fmt.Errorf("invalid ICMP echo reply; type: '%T', '%v'", pkt, pkt)
 	}
 
-	p.rtts = append(p.rtts, outPkt.Rtt)
+	if p.RecordRtts {
+		p.rtts = append(p.rtts, outPkt.Rtt)
+	}
 	handler := p.OnRecv
 	if handler != nil {
 		handler(outPkt)

--- a/ping.go
+++ b/ping.go
@@ -76,11 +76,12 @@ var (
 func New(addr string) *Pinger {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &Pinger{
-		Count:    -1,
-		Interval: time.Second,
-		Size:     timeSliceLength,
-		Timeout:  time.Second * 100000,
-		Tracker:  r.Int63n(math.MaxInt64),
+		Count:      -1,
+		Interval:   time.Second,
+		RecordRtts: true,
+		Size:       timeSliceLength,
+		Timeout:    time.Second * 100000,
+		Tracker:    r.Int63n(math.MaxInt64),
 
 		addr:     addr,
 		done:     make(chan bool),


### PR DESCRIPTION
This prevents memory bloat from a process that wants to do very long running ping tests.

This was previously included by accident in PR 104.