### PR TITLE
Add Reset method to be able to re-use the Pinger instance

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -518,6 +518,16 @@ func (p *Pinger) Stop() {
 	}
 }
 
+// Reset sets the RTTs and the sent and received counts
+// back to zero so that Run can be re-used on the same
+// instance.
+func (p *Pinger) Reset() {
+	p.done = make(chan bool)
+	p.rtts = make([]time.Duration, 0)
+	p.PacketsSent = 0
+	p.PacketsRecv = 0
+}
+
 func (p *Pinger) finish() {
 	handler := p.OnFinish
 	if handler != nil {


### PR DESCRIPTION
I have a specific use case where I want to periodically determine the RTT to a server. 

I tried to re-use the `Pinger` instance and used `Run` on every ticker elapse on the same instance. The result was that every following `Statistics` instance contained the same RTT times. Below, you can find the snippet for this.
https://gist.github.com/zekroTJA/ae3dbbe2dbbe56b3c1be9775f77718f5

To be able to re-use the `Pinger` instance, I have added a `Reset` method which reinitializes the `done` channel and the `rtts` array and sets the values of `PacketsSent` and `PacketsRecv` back to zero.