### PR TITLE
Make default Timeout "forever"

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -81,7 +81,7 @@ func New(addr string) *Pinger {
 		Interval:   time.Second,
 		RecordRtts: true,
 		Size:       timeSliceLength,
-		Timeout:    time.Second * 100000,
+		Timeout:    time.Duration(math.MaxInt64),
 		Tracker:    r.Int63n(math.MaxInt64),
 
 		addr:     addr,


### PR DESCRIPTION
Make the default Timeout setting the maximum Go Duration, which is
290 years. Effectively forever.

Signed-off-by: Ben Kochie <superq@gmail.com>