### PR TITLE
add trackerLength to p.Size in New()

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -89,7 +89,7 @@ func New(addr string) *Pinger {
 		Count:      -1,
 		Interval:   time.Second,
 		RecordRtts: true,
-		Size:       timeSliceLength,
+		Size:       timeSliceLength + trackerLength,
 		Timeout:    time.Second * 100000,
 		Tracker:    r.Int63n(math.MaxInt64),
 


### PR DESCRIPTION
Hi, there  

Refer to the ```go-fastping``` repository as it sends ```icmp.Echo``` message and transforms current timestamp to bytes array with length 8 as the data body. So ```go-fastping``` set p.Size = 8 which is timeSliceLength in constructor.

However, this ```ping``` repo uses the current timestamp as well as the unique tracker int as the data body. Therefore, I think ```p.Size``` inside the ```New()``` constructor should add trackerLength.  

issue #124 