### PR TITLE
Process duplicate packets and make seeds goroutine-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ err = pinger.Run() // Blocks until finished.
 if err != nil {
 	panic(err)
 }
-stats := pinger.Statistics() // get send/receive/rtt stats
+stats := pinger.Statistics() // get send/receive/duplicate/rtt stats
 ```
 
 Here is an example that emulates the traditional UNIX ping command:
@@ -42,6 +42,11 @@ pinger.OnRecv = func(pkt *ping.Packet) {
 		pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt)
 }
 
+pinger.OnDuplicateRecv = func(pkt *ping.Packet) {
+	fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",
+		pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
+}
+
 pinger.OnFinish = func(stats *ping.Statistics) {
 	fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
 	fmt.Printf("%d packets transmitted, %d packets received, %v%% packet loss\n",
@@ -58,8 +63,10 @@ if err != nil {
 ```
 
 It sends ICMP Echo Request packet(s) and waits for an Echo Reply in
-response. If it receives a response, it calls the `OnRecv` callback.
-When it's finished, it calls the `OnFinish` callback.
+response. If it receives a response, it calls the `OnRecv` callback
+unless a packet with that sequence number has already been received,
+in which case it calls the `OnDuplicateRecv` callback. When it's
+finished, it calls the `OnFinish` callback.
 
 For a full ping example, see
 [cmd/ping/ping.go](https://github.com/go-ping/ping/blob/master/cmd/ping/ping.go).

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -68,10 +68,14 @@ func main() {
 		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
 			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
 	}
+	pinger.OnDuplicateRecv = func(pkt *ping.Packet) {
+		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",
+			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
+	}
 	pinger.OnFinish = func(stats *ping.Statistics) {
 		fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
-		fmt.Printf("%d packets transmitted, %d packets received, %v%% packet loss\n",
-			stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
+		fmt.Printf("%d packets transmitted, %d packets received, %d duplicates, %v%% packet loss\n",
+			stats.PacketsSent, stats.PacketsRecv, stats.PacketsRecvDuplicates, stats.PacketLoss)
 		fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
 			stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 	}

--- a/ping.go
+++ b/ping.go
@@ -96,7 +96,7 @@ func New(addr string) *Pinger {
 
 		addr:              addr,
 		done:              make(chan bool),
-		id:                r.Intn(math.MaxInt32),
+		id:                r.Intn(math.MaxInt16),
 		ipaddr:            nil,
 		ipv4:              false,
 		network:           "ip",

--- a/ping.go
+++ b/ping.go
@@ -553,7 +553,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 
 		outPkt.Rtt = receivedAt.Sub(timestamp)
 		outPkt.Seq = pkt.Seq
-		// if we've already received this sequence, ignore it.
+		// If we've already received this sequence, ignore it.
 		if _, inflight := p.awaitingSequences[pkt.Seq]; !inflight {
 			return nil
 		}

--- a/ping_test.go
+++ b/ping_test.go
@@ -29,6 +29,7 @@ func TestProcessPacket(t *testing.T) {
 		Seq:  pinger.sequence,
 		Data: data,
 	}
+	pinger.awaitingSequences[pinger.sequence] = struct{}{}
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
@@ -568,6 +569,8 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 		Seq:  0,
 		Data: data,
 	}
+	// register the sequence as sent
+	pinger.awaitingSequences[0] = struct{}{}
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,


### PR DESCRIPTION
We were seeing some issues with packets being delivered multiple times, suspecting duplicate sequence numbers resulting in duplicate counting of received packets and negative loss percentage.

Cleaned up some code around unique IDs and potentially overlapping IDs resulting from bad random number seeds.

- ignores second delivery of same sequence number.
- make seeds goroutine-safe so we never have a duplicate seed
- expand id to int32 rather than int16 so that we never get collisions, and there was space to do this anyway.

Fixes #14 