### PR TITLE
Make Tracker uint64 and check for both UDP and ICMP

### DIFF
--- a/ping_test.go
+++ b/ping_test.go
@@ -19,7 +19,7 @@ func TestProcessPacket(t *testing.T) {
 		shouldBe1++
 	}
 
-	data := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	data := append(timeToBytes(time.Now()), uintToBytes(pinger.Tracker)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -58,7 +58,7 @@ func TestProcessPacket_IgnoreNonEchoReplies(t *testing.T) {
 		shouldBe0++
 	}
 
-	data := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	data := append(timeToBytes(time.Now()), uintToBytes(pinger.Tracker)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -97,7 +97,7 @@ func TestProcessPacket_IDMismatch(t *testing.T) {
 		shouldBe0++
 	}
 
-	data := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	data := append(timeToBytes(time.Now()), uintToBytes(pinger.Tracker)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -135,7 +135,7 @@ func TestProcessPacket_TrackerMismatch(t *testing.T) {
 		shouldBe0++
 	}
 
-	data := append(timeToBytes(time.Now()), intToBytes(999)...)
+	data := append(timeToBytes(time.Now()), uintToBytes(999)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -169,7 +169,7 @@ func TestProcessPacket_LargePacket(t *testing.T) {
 	pinger := makeTestPinger()
 	pinger.Size = 4096
 
-	data := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	data := append(timeToBytes(time.Now()), uintToBytes(pinger.Tracker)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -520,7 +520,7 @@ func BenchmarkProcessPacket(b *testing.B) {
 	pinger.id = 123
 	pinger.Tracker = 456
 
-	t := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	t := append(timeToBytes(time.Now()), uintToBytes(pinger.Tracker)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		t = append(t, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -565,7 +565,7 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 		dups++
 	}
 
-	data := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	data := append(timeToBytes(time.Now()), uintToBytes(pinger.Tracker)...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}


### PR DESCRIPTION
It looks like we can check a received packet's `ID` in both UDP and ICMP so we might as well. This PR also reduces some needless complexity by making `Tracker` an unsigned 64-bit int.

Fixes #133.