### PR TITLE
Correctly deserialise ICMP messages

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -472,7 +472,8 @@ func (p *Pinger) recvICMP(
 		case <-p.done:
 			return nil
 		default:
-			bytes := make([]byte, 512)
+			// ICMP messages have an 8-byte header.
+			bytes := make([]byte, p.Size+8)
 			if err := conn.SetReadDeadline(time.Now().Add(time.Millisecond * 100)); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR makes sure that the array into which received ICMP messages are deserialised is sized appropriately for the `Pinger`.

Fixes #137