### PR TITLE
Fix size issue when deserialising on Windows

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -472,18 +472,7 @@ func (p *Pinger) recvICMP(
 		case <-p.done:
 			return nil
 		default:
-			// ICMP messages have an 8-byte header.
-			length := p.Size + 8
-			// But on Windows we have to deserialise the whole
-			// IP packet, not just the message in its payload.
-			if runtime.GOOS == "windows" {
-				if p.ipv4 {
-					length += ipv4.HeaderLen
-				} else {
-					length += ipv6.HeaderLen
-				}
-			}
-			bytes := make([]byte, length)
+			bytes := make([]byte, p.getMessageLength())
 			if err := conn.SetReadDeadline(time.Now().Add(time.Millisecond * 100)); err != nil {
 				return err
 			}

--- a/ping.go
+++ b/ping.go
@@ -473,7 +473,17 @@ func (p *Pinger) recvICMP(
 			return nil
 		default:
 			// ICMP messages have an 8-byte header.
-			bytes := make([]byte, p.Size+8)
+			length := p.Size + 8
+			// But on Windows we have to deserialise the whole
+			// IP packet, not just the message in its payload.
+			if runtime.GOOS == "windows" {
+				if p.ipv4 {
+					length += ipv4.HeaderLen
+				} else {
+					length += ipv6.HeaderLen
+				}
+			}
+			bytes := make([]byte, length)
 			if err := conn.SetReadDeadline(time.Now().Add(time.Millisecond * 100)); err != nil {
 				return err
 			}

--- a/utils_other.go
+++ b/utils_other.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package ping
+
+// Returns the length of an ICMP message.
+func (p *Pinger) getMessageLength() int {
+	return p.Size + 8
+}

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -1,0 +1,16 @@
+// +build windows
+
+package ping
+
+import (
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// Returns the length of an ICMP message, plus the IP packet header.
+func (p *Pinger) getMessageLength() int {
+	if p.ipv4 {
+		return p.Size + 8 + ipv4.HeaderLen
+	}
+	return p.Size + 8 + ipv6.HeaderLen
+}


### PR DESCRIPTION
#138 introduced some new behavior to make sure the data structure into which we deserialise ICMP messages is sized correctly. However it looks like there's some kind of weird incompatibility problem -- what works on Linux and macOS doesn't work on Windows unless the length of the IP packet header as also added on to the size.

This PR fixes #143 and makes the pinger work on Windows again.