### PR TITLE
Fix unprivileged packet matching on Linux

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -541,8 +541,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 
 	switch pkt := m.Body.(type) {
 	case *icmp.Echo:
-		// Check if the reply has the ID we expect.
-		if pkt.ID != p.id {
+		if !p.matchID(pkt.ID) {
 			return nil
 		}
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+// +build linux
 
 package ping
 
@@ -9,8 +9,11 @@ func (p *Pinger) getMessageLength() int {
 
 // Attempts to match the ID of an ICMP packet.
 func (p *Pinger) matchID(ID int) bool {
-	if ID != p.id {
-		return false
+	// On Linux we can only match ID if we are privileged.
+	if p.protocol == "icmp" {
+		if ID != p.id {
+			return false
+		}
 	}
 	return true
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -14,3 +14,11 @@ func (p *Pinger) getMessageLength() int {
 	}
 	return p.Size + 8 + ipv6.HeaderLen
 }
+
+// Attempts to match the ID of an ICMP packet.
+func (p *Pinger) matchID(ID int) bool {
+	if ID != p.id {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
62f79f1f4f36fc821eebb131548270d4d8b68653 changed the matching of ICMP IDs so that it happened in both privileged an unprivileged modes. I played around and tested this on macOS and Windows but not on Linux which, it seems, behaves differently.

This introduces a platform-dependant matching function using build constraints. Fixes #146.