### PR TITLE
Bump Go version to v1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 executors:
   golang:
     docker:
-    - image: cimg/go:1.15
+    - image: cimg/go:1.16
 
 version: 2.1
 jobs:


### PR DESCRIPTION
Updates the version of Go used in Circle to 1.16 so that we can use goreleaser to test building for the darwin_arm64 target.

Discovered via #147.