### PR TITLE
Compute all statistics as packets are received 

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -541,8 +541,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 
 	switch pkt := m.Body.(type) {
 	case *icmp.Echo:
-		// Check if the reply has the ID we expect.
-		if pkt.ID != p.id {
+		if !p.matchID(pkt.ID) {
 			return nil
 		}
 

--- a/ping.go
+++ b/ping.go
@@ -532,7 +532,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 		return nil
 	}
 
-	outPkt := &Packet{
+	inPkt := &Packet{
 		Nbytes: recv.nbytes,
 		IPAddr: p.ipaddr,
 		Addr:   p.addr,
@@ -557,13 +557,13 @@ func (p *Pinger) processPacket(recv *packet) error {
 			return nil
 		}
 
-		outPkt.Rtt = receivedAt.Sub(timestamp)
-		outPkt.Seq = pkt.Seq
+		inPkt.Rtt = receivedAt.Sub(timestamp)
+		inPkt.Seq = pkt.Seq
 		// If we've already received this sequence, ignore it.
 		if _, inflight := p.awaitingSequences[pkt.Seq]; !inflight {
 			p.PacketsRecvDuplicates++
 			if p.OnDuplicateRecv != nil {
-				p.OnDuplicateRecv(outPkt)
+				p.OnDuplicateRecv(inPkt)
 			}
 			return nil
 		}
@@ -576,11 +576,11 @@ func (p *Pinger) processPacket(recv *packet) error {
 	}
 
 	if p.RecordRtts {
-		p.rtts = append(p.rtts, outPkt.Rtt)
+		p.rtts = append(p.rtts, inPkt.Rtt)
 	}
 	handler := p.OnRecv
 	if handler != nil {
-		handler(outPkt)
+		handler(inPkt)
 	}
 
 	return nil

--- a/ping_test.go
+++ b/ping_test.go
@@ -373,19 +373,16 @@ func TestStatisticsSunny(t *testing.T) {
 	AssertEqualStrings(t, "localhost", p.Addr())
 
 	p.PacketsSent = 10
-	p.PacketsRecv = 10
-	p.rtts = []time.Duration{
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(1000),
-	}
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
 
 	stats := p.Statistics()
 	if stats.PacketsRecv != 10 {
@@ -419,19 +416,16 @@ func TestStatisticsLossy(t *testing.T) {
 	AssertEqualStrings(t, "localhost", p.Addr())
 
 	p.PacketsSent = 20
-	p.PacketsRecv = 10
-	p.rtts = []time.Duration{
-		time.Duration(10),
-		time.Duration(1000),
-		time.Duration(1000),
-		time.Duration(10000),
-		time.Duration(1000),
-		time.Duration(800),
-		time.Duration(1000),
-		time.Duration(40),
-		time.Duration(100000),
-		time.Duration(1000),
-	}
+	p.updateStatistics(&Packet{Rtt: time.Duration(10)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(10000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(800)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(40)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(100000)})
+	p.updateStatistics(&Packet{Rtt: time.Duration(1000)})
 
 	stats := p.Statistics()
 	if stats.PacketsRecv != 10 {

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+// +build linux
 
 package ping
 
@@ -9,8 +9,11 @@ func (p *Pinger) getMessageLength() int {
 
 // Attempts to match the ID of an ICMP packet.
 func (p *Pinger) matchID(ID int) bool {
-	if ID != p.id {
-		return false
+	// On Linux we can only match ID if we are privileged.
+	if p.protocol == "icmp" {
+		if ID != p.id {
+			return false
+		}
 	}
 	return true
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -14,3 +14,11 @@ func (p *Pinger) getMessageLength() int {
 	}
 	return p.Size + 8 + ipv6.HeaderLen
 }
+
+// Attempts to match the ID of an ICMP packet.
+func (p *Pinger) matchID(ID int) bool {
+	if ID != p.id {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
This PR implements [Welford's online algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) to compute the standard deviation of the round trip times as packets are received without storing the full list. (the average is taken from this algorithm too)
As for min and max, they are also computed as we go.

I didn't touch the `rtts` array since it is part of the public interface of the Statistics, but with this PR it is not needed to get the stats.

I wasn't sure what to do about the tests which set `p.PacketsRecv` and then filled `p.rtts` with test values.
Since the packet count is an inherent part of the algorithm, I opted to move the increment into the `updateStatistic` method and repeatedly call it with test data.

One other thing: I think calling `Statistics()` from another goroutine could yield incorrect results since `updateStatistics()` could be running at the same time. Adding a RWLock should fix that. (I haven't done it yet since I do not use Pinger in this fashion and this particular problem was present in the original code where rtts can be modified while `Statistics()` is called)

There's also a commit that renames `outPkt` to `inPkt` in `processPacket` since that function is dealing with received packets.

(And this is all branched off b92053f because otherwise go-ping doesn't work on linux at the moment)

It might be easier to review commit by commit since they are self contained.