### PR TITLE
Protect stats with RWMutex 

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -143,6 +143,7 @@ type Pinger struct {
 	avgRtt    time.Duration
 	stdDevRtt time.Duration
 	stddevm2  time.Duration
+	statsmu   sync.RWMutex
 
 	// If true, keep a record of rtts of all received packets.
 	// Set to false to avoid memory bloat for long running pings.
@@ -255,7 +256,14 @@ type Statistics struct {
 }
 
 func (p *Pinger) updateStatistics(pkt *Packet) {
+	p.statsmu.Lock()
+	defer p.statsmu.Unlock()
+
 	p.PacketsRecv++
+	if p.RecordRtts {
+		p.rtts = append(p.rtts, pkt.Rtt)
+	}
+
 	if p.PacketsRecv == 1 || pkt.Rtt < p.minRtt {
 		p.minRtt = pkt.Rtt
 	}
@@ -451,9 +459,12 @@ func (p *Pinger) finish() {
 // pinger is running or after it is finished. OnFinish calls this function to
 // get it's finished statistics.
 func (p *Pinger) Statistics() *Statistics {
-	loss := float64(p.PacketsSent-p.PacketsRecv) / float64(p.PacketsSent) * 100
+	p.statsmu.RLock()
+	defer p.statsmu.RUnlock()
+	sent := p.PacketsSent
+	loss := float64(sent-p.PacketsRecv) / float64(sent) * 100
 	s := Statistics{
-		PacketsSent:           p.PacketsSent,
+		PacketsSent:           sent,
 		PacketsRecv:           p.PacketsRecv,
 		PacketsRecvDuplicates: p.PacketsRecvDuplicates,
 		PacketLoss:            loss,
@@ -582,9 +593,6 @@ func (p *Pinger) processPacket(recv *packet) error {
 		return fmt.Errorf("invalid ICMP echo reply; type: '%T', '%v'", pkt, pkt)
 	}
 
-	if p.RecordRtts {
-		p.rtts = append(p.rtts, inPkt.Rtt)
-	}
 	handler := p.OnRecv
 	if handler != nil {
 		handler(inPkt)

--- a/ping.go
+++ b/ping.go
@@ -143,7 +143,7 @@ type Pinger struct {
 	avgRtt    time.Duration
 	stdDevRtt time.Duration
 	stddevm2  time.Duration
-	statsmu   sync.RWMutex
+	statsMu   sync.RWMutex
 
 	// If true, keep a record of rtts of all received packets.
 	// Set to false to avoid memory bloat for long running pings.
@@ -256,8 +256,8 @@ type Statistics struct {
 }
 
 func (p *Pinger) updateStatistics(pkt *Packet) {
-	p.statsmu.Lock()
-	defer p.statsmu.Unlock()
+	p.statsMu.Lock()
+	defer p.statsMu.Unlock()
 
 	p.PacketsRecv++
 	if p.RecordRtts {
@@ -459,8 +459,8 @@ func (p *Pinger) finish() {
 // pinger is running or after it is finished. OnFinish calls this function to
 // get it's finished statistics.
 func (p *Pinger) Statistics() *Statistics {
-	p.statsmu.RLock()
-	defer p.statsmu.RUnlock()
+	p.statsMu.RLock()
+	defer p.statsMu.RUnlock()
 	sent := p.PacketsSent
 	loss := float64(sent-p.PacketsRecv) / float64(sent) * 100
 	s := Statistics{


### PR DESCRIPTION
This is more of a request for comments than a proper PR (and it is branched off #150  so only the last commit should be reviewed )

A RWMutex is added to protect access to  the Pinger's internal statistics.
Updates to `rtts` is moved to `updateStats` so they happen under the lock.

There's (at least) one issue however: PacketsSent and PacketsRecvDuplicates can still be updated while
Statistics() is running, and thus could yield strange results (sent<recv)

To fix this, atomics could be used, but it would require changing the types of the fields from int to int64, thus changing the public api of Pinger. (One could argue that those fields should probably not be exported to begin with, but that would break the api too)

Any thoughts?