### PR TITLE
Wrap errors when using fmt.Errorf

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -524,7 +524,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 	var m *icmp.Message
 	var err error
 	if m, err = icmp.ParseMessage(proto, recv.bytes); err != nil {
-		return fmt.Errorf("error parsing icmp message: %s", err.Error())
+		return fmt.Errorf("error parsing icmp message: %w", err)
 	}
 
 	if m.Type != ipv4.ICMPTypeEchoReply && m.Type != ipv6.ICMPTypeEchoReply {


### PR DESCRIPTION
Nit: wrap errors using `%w` to allow the use of the `errors.Is` function. https://blog.golang.org/go1.13-errors

Currently the returned error is only used internally and it simply gets logged if not `nil`:

https://github.com/go-ping/ping/blob/22d47451d074c67c29d130af1ce96f45edb4e30d/ping.go#L399

However #16 wants to change this and return errors to the end user so this PR will invariably help when #16 is resolved.