### PR TITLE
Add OnSetup callback

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -152,6 +152,9 @@ type Pinger struct {
 	// rtts is all of the Rtts
 	rtts []time.Duration
 
+	// OnSetup is called when Pinger has finished setting up the listening socket
+	OnSetup func()
+
 	// OnSend is called when Pinger sends a packet
 	OnSend func(*Packet)
 
@@ -399,6 +402,10 @@ func (p *Pinger) Run() error {
 	wg.Add(1)
 	//nolint:errcheck
 	go p.recvICMP(conn, recv, &wg)
+
+	if handler := p.OnSetup; handler != nil {
+		handler()
+	}
 
 	err = p.sendICMP(conn)
 	if err != nil {


### PR DESCRIPTION
It allows users to do something after the listening socket is set up but
before the first packet is sent. One specific use case is measuring the
time it takes the system to *send* the first packet.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>