### PR TITLE
Reorder channel selection order and make Stop() idempotent

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -409,19 +409,18 @@ func (p *Pinger) Run() error {
 
 	timeout := time.NewTicker(p.Timeout)
 	interval := time.NewTicker(p.Interval)
+	defer func() {
+		interval.Stop()
+		timeout.Stop()
+		wg.Wait()
+	}()
 
 	for {
 		select {
 		case <-p.done:
-			interval.Stop()
-			timeout.Stop()
-			wg.Wait()
 			return nil
 		case <-timeout.C:
 			close(p.done)
-			interval.Stop()
-			timeout.Stop()
-			wg.Wait()
 			return nil
 		case r := <-recv:
 			err := p.processPacket(r)
@@ -442,9 +441,6 @@ func (p *Pinger) Run() error {
 		}
 		if p.Count > 0 && p.PacketsRecv >= p.Count {
 			close(p.done)
-			interval.Stop()
-			timeout.Stop()
-			wg.Wait()
 			return nil
 		}
 	}

--- a/ping.go
+++ b/ping.go
@@ -417,6 +417,11 @@ func (p *Pinger) Run() error {
 		wg.Wait()
 	}()
 
+	err = p.sendICMP(conn)
+	if err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-p.done:

--- a/ping.go
+++ b/ping.go
@@ -452,7 +452,7 @@ func (p *Pinger) Stop() {
 
 	open := true
 	select {
-	case _, ok = <-p.done:
+	case _, open = <-p.done:
 	default:
 	}
 


### PR DESCRIPTION
This PR:

- Reorders the channels in the main select clause of the `Run()` function so that we always deal with received packets first rather than sending new packet out. This is so that the TTL values don't go stale when pinging very rapidly (cf. #154).
- Improves CPU usage slightly by greedily calling `Stop()` on tickers where possible.
- Removes the initial packet sent around line 403 which I can't really see a need for.