### PR TITLE
Provide an abstraction over icmp.PacketConn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/go-ping/ping
 
 go 1.14
 
-require golang.org/x/net v0.0.0-20200904194848-62affa334b73
+require (
+	golang.org/x/net v0.0.0-20200904194848-62affa334b73
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=

--- a/packetconn.go
+++ b/packetconn.go
@@ -1,0 +1,86 @@
+package ping
+
+import (
+	"net"
+	"runtime"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+type packetConn interface {
+	Close() error
+	ICMPRequestType() icmp.Type
+	ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error)
+	SetFlagTTL() error
+	SetReadDeadline(t time.Time) error
+	WriteTo(b []byte, dst net.Addr) (int, error)
+}
+
+type icmpConn struct {
+	c *icmp.PacketConn
+}
+
+func (c *icmpConn) Close() error {
+	return c.c.Close()
+}
+
+func (c *icmpConn) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
+}
+
+func (c *icmpConn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	return c.c.WriteTo(b, dst)
+}
+
+type icmpv4Conn struct {
+	icmpConn
+}
+
+func (c *icmpv4Conn) SetFlagTTL() error {
+	err := c.c.IPv4PacketConn().SetControlMessage(ipv4.FlagTTL, true)
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return err
+}
+
+func (c *icmpv4Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
+	var ttl int
+	n, cm, src, err := c.c.IPv4PacketConn().ReadFrom(b)
+	if cm != nil {
+		ttl = cm.TTL
+	}
+	return n, ttl, src, err
+}
+
+func (c icmpv4Conn) ICMPRequestType() icmp.Type {
+	return ipv4.ICMPTypeEcho
+}
+
+type icmpV6Conn struct {
+	icmpConn
+}
+
+func (c *icmpV6Conn) SetFlagTTL() error {
+	err := c.c.IPv6PacketConn().SetControlMessage(ipv6.FlagHopLimit, true)
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return err
+}
+
+func (c *icmpV6Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
+	var ttl int
+	n, cm, src, err := c.c.IPv6PacketConn().ReadFrom(b)
+	if cm != nil {
+		ttl = cm.HopLimit
+	}
+	return n, ttl, src, err
+}
+
+func (c icmpV6Conn) ICMPRequestType() icmp.Type {
+	return ipv6.ICMPTypeEchoRequest
+}


### PR DESCRIPTION
The differences between ipv4 and ipv6 APIs can be moved to a single type
so that we don't need to keep track of them all over the code.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>
