### PR TITLE
Only check icmp ID match when on privileged

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -611,8 +611,12 @@ func (p *Pinger) processPacket(recv *packet) error {
 
 	switch pkt := m.Body.(type) {
 	case *icmp.Echo:
-		if !p.matchID(pkt.ID) {
-			return nil
+		// If we are priviledged, we can match icmp.ID
+		if p.protocol == "icmp" {
+			// Check if reply from same ID
+			if !p.matchID(pkt.ID) {
+				return nil
+			}
 		}
 
 		if len(pkt.Data) < timeSliceLength+trackerLength {


### PR DESCRIPTION
Fixes #180 

When on non-privileged role, linux kernel would only automatically
sequential increment the identifier.

Signed-off-by: Hu Keping <hukeping@huawei.com>
Signed-off-by: Li Guoshuai <liguoshuai@huawei.com>