### PR TITLE
Maintenance: add more linters to golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: go mod download
-      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
+      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
       - run: golangci-lint run
       - run: make
       - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 linters-settings:
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ issues:
         - goerr113
 
 linters:
-  disable-all: true
   enable:
     - asciicheck
     - bodyclose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,11 +16,9 @@ linters:
     - asciicheck
     - bodyclose
     # - cyclop - enable later
-    - deadcode
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errname
     - errorlint
     - exhaustive
@@ -41,11 +39,8 @@ linters:
     - gomoddirectives
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - importas
     - importas
-    - ineffassign
     - lll
     - makezero
     - misspell
@@ -61,15 +56,10 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    - staticcheck
-    - structcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
-    - varcheck
     - wastedassign
     - whitespace
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,79 @@
----
+linters-settings:
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+
 issues:
   exclude-rules:
-  - path: _test.go
-    linters:
+    - path: _test\.go
+      linters:
+        - dupl
+        - goerr113
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    # - cyclop - enable later
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
     - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gci
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goerr113
+    - goheader
+    - goimports
+    - gomnd
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - importas
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+
+run:
+  skip-dirs:
+    - .circleci

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-ping/ping"
 )
 
-var usage = `
+const usage = `
 Usage:
 
     ping [-c count] [-i interval] [-t timeout] [--privileged] host
@@ -37,10 +37,12 @@ Examples:
 `
 
 func main() {
-	timeout := flag.Duration("t", time.Second*100000, "")
+	const defaultTimeout = time.Second * 100000
+	timeout := flag.Duration("t", defaultTimeout, "")
 	interval := flag.Duration("i", time.Second, "")
 	count := flag.Int("c", -1, "")
-	size := flag.Int("s", 24, "")
+	const defaultSize = 24
+	size := flag.Int("s", defaultSize, "")
 	privileged := flag.Bool("privileged", false, "")
 	flag.Usage = func() {
 		fmt.Print(usage)

--- a/ping_test.go
+++ b/ping_test.go
@@ -476,7 +476,7 @@ func TestStatisticsLossy(t *testing.T) {
 	}
 }
 
-// Test helpers
+// Test helpers.
 func makeTestPinger() *Pinger {
 	pinger := New("127.0.0.1")
 
@@ -573,7 +573,7 @@ func BenchmarkProcessPacket(b *testing.B) {
 	}
 
 	for k := 0; k < b.N; k++ {
-		pinger.processPacket(&pkt)
+		_ = pinger.processPacket(&pkt)
 	}
 }
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -1,19 +1,19 @@
+//go:build linux
 // +build linux
 
 package ping
 
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
-	return p.Size + 8
+	const extraSize = 8
+	return p.Size + extraSize
 }
 
-// Attempts to match the ID of an ICMP packet.
-func (p *Pinger) matchID(ID int) bool {
-	// On Linux we can only match ID if we are privileged.
-	if p.protocol == "icmp" {
-		if ID != p.id {
-			return false
-		}
+// Attempts to match the id of an ICMP packet.
+func (p *Pinger) matchID(id int) bool {
+	if p.protocol != icmpStr {
+		return true
 	}
-	return true
+	// On Linux we can only match ID if we are privileged.
+	return id == p.id
 }

--- a/utils_other.go
+++ b/utils_other.go
@@ -1,16 +1,15 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package ping
 
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
-	return p.Size + 8
+	const extraSize = 8
+	return p.Size + extraSize
 }
 
-// Attempts to match the ID of an ICMP packet.
-func (p *Pinger) matchID(ID int) bool {
-	if ID != p.id {
-		return false
-	}
-	return true
+// Attempts to match the id of an ICMP packet.
+func (p *Pinger) matchID(id int) bool {
+	return id == p.id
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package ping
@@ -9,16 +10,14 @@ import (
 
 // Returns the length of an ICMP message, plus the IP packet header.
 func (p *Pinger) getMessageLength() int {
+	const extraSize = 8
 	if p.ipv4 {
-		return p.Size + 8 + ipv4.HeaderLen
+		return p.Size + extraSize + ipv4.HeaderLen
 	}
-	return p.Size + 8 + ipv6.HeaderLen
+	return p.Size + extraSize + ipv6.HeaderLen
 }
 
-// Attempts to match the ID of an ICMP packet.
-func (p *Pinger) matchID(ID int) bool {
-	if ID != p.id {
-		return false
-	}
-	return true
+// Attempts to match the id of an ICMP packet.
+func (p *Pinger) matchID(id int) bool {
+	return id == p.id
 }


### PR DESCRIPTION
- Use a maphash source instead of time based global variable
- Add exported wrapping errors
- Add unexported wrapping errors to add more context to the errors
- Small code changes to satisfy all linters (e.g. adding inlined constants)