### PR TITLE
Feat: `Pinger`'s `RunWithContext` method

### DIFF
--- a/ping_test.go
+++ b/ping_test.go
@@ -795,7 +795,6 @@ func TestRunWithContext(t *testing.T) {
 			t.Parallel()
 
 			pinger := New("127.0.0.1")
-			pinger.SetPrivileged(true)
 			pinger.Count = testCase.count
 
 			err := pinger.RunWithContext(testCase.ctx)

--- a/ping_test.go
+++ b/ping_test.go
@@ -783,7 +783,7 @@ func TestRunWithContext(t *testing.T) {
 		"canceled context": {
 			ctx: canceledCtx,
 			// to avoid race condition in the select block
-			count:    100,
+			count:    10,
 			interval: time.Second,
 			err:      context.Canceled,
 		},


### PR DESCRIPTION
- [x] Method with comment
- [x] Unit test
  - [ ] Not sure how to go around testing this without root in the CI, any idea?
- [x] This is used in 'production' [here](https://github.com/qdm12/gluetun/blob/f7e4331e933a396c9279b48340e1284a98fe50d5/internal/healthcheck/health.go#L61-L77)
- [ ] Document in readme?
