### PR TITLE
Always update Packet's addresses

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -211,6 +211,7 @@ type packet struct {
 	bytes  []byte
 	nbytes int
 	ttl    int
+	addr   *net.IPAddr
 }
 
 // Packet represents a received and processed ICMP echo packet.
@@ -574,7 +575,8 @@ func (p *Pinger) recvICMP(
 			}
 			var n, ttl int
 			var err error
-			n, ttl, _, err = conn.ReadFrom(bytes)
+			var addr net.Addr
+			n, ttl, addr, err = conn.ReadFrom(bytes)
 			if err != nil {
 				if neterr, ok := err.(*net.OpError); ok {
 					if neterr.Timeout() {
@@ -586,10 +588,23 @@ func (p *Pinger) recvICMP(
 				return err
 			}
 
+			// Make sure to use the received address from the packet as for multicast
+			// the response might come from other IP addresses
+			ipaddr, ok := addr.(*net.IPAddr)
+			if !ok {
+				udpaddr, ok := addr.(*net.UDPAddr)
+				if !ok {
+					// Should never occur
+					return fmt.Errorf("error parsing the address")
+				}
+
+				ipaddr = &net.IPAddr{IP: udpaddr.IP}
+			}
+
 			select {
 			case <-p.done:
 				return nil
-			case recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}:
+			case recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl, addr: ipaddr}:
 			}
 		}
 	}
@@ -638,8 +653,8 @@ func (p *Pinger) processPacket(recv *packet) error {
 
 	inPkt := &Packet{
 		Nbytes: recv.nbytes,
-		IPAddr: p.ipaddr,
-		Addr:   p.addr,
+		IPAddr: recv.addr,
+		Addr:   recv.addr.String(),
 		Ttl:    recv.ttl,
 	}
 


### PR DESCRIPTION
Hi,

When a ping is performed on multicast addresses, the lib currently provides the address of the original destination in the callbacks. However, in this case the reply will come from another (existing) address. It is useful to provide the actual replied address to the callback instead of the original one (see the output below).

The output of ping without this patch is:

```
$ sudo ping --privileged ff02::1%ens3
PING ff02::1%ens3 (ff02::1%ens3):
24 bytes from ff02::1%ens3: icmp_seq=0 time=1.504454ms ttl=64
24 bytes from ff02::1%ens3: icmp_seq=0 time=1.553965ms ttl=64 (DUP!)
24 bytes from ff02::1%ens3: icmp_seq=0 time=1.580495ms ttl=64 (DUP!)
24 bytes from ff02::1%ens3: icmp_seq=0 time=1.596156ms ttl=64 (DUP!)
```

And with this patch:

```
$ sudo ./ping --privileged ff02::1%ens3
PING ff02::1%ens3 (ff02::1%ens3):
32 bytes from fe80::546f:f0ff:fe0e:a%ens3: icmp_seq=0 time=1.256761ms ttl=64
32 bytes from fe80::546f:f0ff:fe0e:29%ens3: icmp_seq=0 time=1.396183ms ttl=64 (DUP!)
32 bytes from fe80::546f:f0ff:fe0e:8%ens3: icmp_seq=0 time=1.447454ms ttl=64 (DUP!)
32 bytes from fe80::546f:f0ff:fe0e:e%ens3: icmp_seq=0 time=1.460754ms ttl=64 (DUP!)
```