### PR TITLE
fixed sometimes failing test

### DIFF
--- a/ping_test.go
+++ b/ping_test.go
@@ -761,5 +761,4 @@ func TestRunOK(t *testing.T) {
 	AssertTrue(t, stats.PacketsSent == 1)
 	AssertTrue(t, stats.PacketsRecv == 1)
 	AssertTrue(t, stats.MinRtt >= 10*time.Millisecond)
-	AssertTrue(t, stats.MinRtt <= 12*time.Millisecond)
 }


### PR DESCRIPTION
I'm using an M1 Mac. Run the test, it will most likely fail.

- The sleep in this line will always take 10ms.
  - https://github.com/go-ping/ping/blob/6e2b003bffdda24160560abd59cc6dfa560ea96c/ping_test.go#L740
- But I don't think there is any guarantee that the processing in `runLoop` will be completed within 12ms. Probably this is the reason.

## How to reproduce

sometimes run this command

```
$ go test -timeout 30s -run "TestRunOK" github.com/go-ping/ping -v -count=1
``` 