### PR TITLE
#195 count packets of which  writes fail still as sent packets + exit run loop in case count is reached

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /ping
 /dist
+.vscode

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pinger.OnDuplicateRecv = func(pkt *ping.Packet) {
 pinger.OnFinish = func(stats *ping.Statistics) {
 	fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
 	fmt.Printf("%d packets transmitted, %d packets received, %v%% packet loss\n",
-		stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
+		stats.CountExecuted, stats.PacketsRecv, stats.PacketLoss)
 	fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
 		stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 }

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -80,7 +80,7 @@ func main() {
 	pinger.OnFinish = func(stats *ping.Statistics) {
 		fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
 		fmt.Printf("%d packets transmitted, %d packets received, %d duplicates, %v%% packet loss\n",
-			stats.PacketsSent, stats.PacketsRecv, stats.PacketsRecvDuplicates, stats.PacketLoss)
+			stats.CountExecuted, stats.PacketsRecv, stats.PacketsRecvDuplicates, stats.PacketLoss)
 		fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
 			stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 	}

--- a/ping_test.go
+++ b/ping_test.go
@@ -676,7 +676,8 @@ func TestRunBadWrite(t *testing.T) {
 	if stats == nil {
 		t.FailNow()
 	}
-	AssertTrue(t, stats.PacketsSent == 1)
+	AssertTrue(t, stats.CountExecuted == 1)
+	AssertTrue(t, stats.PacketsSent == 0)
 	AssertTrue(t, stats.PacketsRecv == 0)
 }
 
@@ -740,6 +741,7 @@ func TestRunBadRead(t *testing.T) {
 	if stats == nil {
 		t.FailNow()
 	}
+	AssertTrue(t, stats.CountExecuted == 1)
 	AssertTrue(t, stats.PacketsSent == 1)
 	AssertTrue(t, stats.PacketsRecv == 0)
 }
@@ -793,6 +795,7 @@ func TestRunOK(t *testing.T) {
 	if stats == nil {
 		t.FailNow()
 	}
+	AssertTrue(t, stats.CountExecuted == 1)
 	AssertTrue(t, stats.PacketsSent == 1)
 	AssertTrue(t, stats.PacketsRecv == 1)
 	AssertTrue(t, stats.MinRtt >= 10*time.Millisecond)


### PR DESCRIPTION
Based on my comparison about how ping in Ubuntu works here is a potential fix which counts packets that cannot be written still as sent packets. The result is equal statistics to standard ping command.

potentially fixes #195 

This approach fails one of the already existing tests which I also modified.

Any suggestions on how to fix this differently is welcome.