### PR TITLE
Delete redundant pinger.Stop() call

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -462,7 +462,6 @@ func (p *Pinger) runLoop(
 	timeout := time.NewTicker(p.Timeout)
 	interval := time.NewTicker(p.Interval)
 	defer func() {
-		p.Stop()
 		interval.Stop()
 		timeout.Stop()
 	}()


### PR DESCRIPTION
Since it's already in 
```
	g.Go(func() error {
		defer p.Stop()
		return p.runLoop(conn, recv)
	})
```