### PR TITLE
Reuse Pinger feature

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -348,6 +348,7 @@ func (p *Pinger) Resolve() error {
 func (p *Pinger) SetAddr(addr string) error {
 	oldAddr := p.addr
 	p.addr = addr
+	p.Reset()
 	err := p.Resolve()
 	if err != nil {
 		p.addr = oldAddr

--- a/ping.go
+++ b/ping.go
@@ -311,6 +311,8 @@ func (p *Pinger) Reset() {
 	p.rtts = make([]time.Duration, 0)
 	p.PacketsSent = 0
 	p.PacketsRecv = 0
+	p.minRtt = 0
+	p.maxRtt = 0
 }
 
 // SetIPAddr sets the ip address of the target host.

--- a/ping.go
+++ b/ping.go
@@ -303,6 +303,16 @@ func (p *Pinger) updateStatistics(pkt *Packet) {
 	p.stdDevRtt = time.Duration(math.Sqrt(float64(p.stddevm2 / pktCount)))
 }
 
+// Reset sets the RTTs and the sent and received counts
+// back to zero so that Run can be re-used on the same
+// instance.
+func (p *Pinger) Reset() {
+	p.done = make(chan interface {})
+	p.rtts = make([]time.Duration, 0)
+	p.PacketsSent = 0
+	p.PacketsRecv = 0
+}
+
 // SetIPAddr sets the ip address of the target host.
 func (p *Pinger) SetIPAddr(ipaddr *net.IPAddr) {
 	p.ipv4 = isIPv4(ipaddr.IP)


### PR DESCRIPTION
Hey I recently needed to ping a list of addresses and I think that instead of needing to create a new pinger each time, it would be easier to just use the same pinger.
As I understood it's not currently possible since the internal state of the pinger does not change when using SetAddr.

Problem and replication described in #198 
I saw someone in the past tried to solve this issue, not sure why the pull request didn't get merged: #117 

659841dbad04df285d05946f9439118f1fcf8729 + 7613ef775df355ab0163a96a66aff5184ed8c270
I added a Reset function to be able to manually reset the internal state of the pinger, specifically packets received and sent, and minimum and maximum Rtt.

2741d0bb576648eee3ec9568d9ce49345f95834b
Added the Reset function to SetAddr so the statistics won't get mixed after changing the address.
I don't think there's a use case for SetAddr unless you also want to re-use the pinger. 

I'm not well versed in github so I apologize if something about this PR is wrong!
Cheers! 😄 