### PR TITLE
Add ability to set outgouing interface (only Linux support)

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -13,7 +13,7 @@ import (
 var usage = `
 Usage:
 
-    ping [-c count] [-i interval] [-t timeout] [--privileged] host
+    ping [-c count] [-i interval] [-t timeout] [-I iface] [--privileged] host
 
 Examples:
 
@@ -37,11 +37,12 @@ Examples:
 `
 
 func main() {
-	timeout := flag.Duration("t", time.Second*100000, "")
-	interval := flag.Duration("i", time.Second, "")
-	count := flag.Int("c", -1, "")
-	size := flag.Int("s", 24, "")
-	ttl := flag.Int("l", 64, "TTL")
+	timeout := flag.Duration("t", time.Second*100000, "time to wait for response")
+	interval := flag.Duration("i", time.Second, "interval between sending each packet")
+	count := flag.Int("c", -1, "stop after replies")
+	size := flag.Int("s", 24, "number of data bytes to be sent")
+	ttl := flag.Int("l", 64, "define time to live")
+	iface := flag.String("I", "", "interface name")
 	privileged := flag.Bool("privileged", false, "")
 	flag.Usage = func() {
 		fmt.Print(usage)
@@ -90,6 +91,7 @@ func main() {
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
 	pinger.TTL = *ttl
+	pinger.Iface = *iface
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())

--- a/packetconn.go
+++ b/packetconn.go
@@ -1,8 +1,11 @@
 package ping
 
 import (
+	"errors"
 	"net"
+	"reflect"
 	"runtime"
+	"syscall"
 	"time"
 
 	"golang.org/x/net/icmp"
@@ -18,6 +21,7 @@ type packetConn interface {
 	SetReadDeadline(t time.Time) error
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	SetTTL(ttl int)
+	BindToDevice(iface string) error
 }
 
 type icmpConn struct {
@@ -35,6 +39,38 @@ func (c *icmpConn) SetTTL(ttl int) {
 
 func (c *icmpConn) SetReadDeadline(t time.Time) error {
 	return c.c.SetReadDeadline(t)
+}
+
+func getConnFD(conn *icmp.PacketConn) (fd int) {
+	var packetConn reflect.Value
+
+	defer func() {
+		if r := recover(); r != nil {
+			fd = -1
+		}
+	}()
+
+	if conn.IPv4PacketConn() != nil {
+		packetConn = reflect.ValueOf(conn.IPv4PacketConn().PacketConn)
+	} else if conn.IPv6PacketConn() != nil {
+		packetConn = reflect.ValueOf(conn.IPv6PacketConn().PacketConn)
+	} else {
+		return -1
+	}
+
+	netFD := reflect.Indirect(reflect.Indirect(packetConn).FieldByName("fd"))
+	pollFD := netFD.FieldByName("pfd")
+	systemFD := pollFD.FieldByName("Sysfd")
+	return int(systemFD.Int())
+}
+
+func (c *icmpConn) BindToDevice(ifName string) error {
+	if runtime.GOOS == "linux" {
+		if fd := getConnFD(c.c); fd >= 0 {
+			return syscall.BindToDevice(fd, ifName)
+		}
+	}
+	return errors.New("bind to interface unsupported") // FIXME: or nil
 }
 
 func (c *icmpConn) WriteTo(b []byte, dst net.Addr) (int, error) {

--- a/ping.go
+++ b/ping.go
@@ -182,6 +182,9 @@ type Pinger struct {
 	// Source is the source IP address
 	Source string
 
+	// Iface used to send/recv ICMP messages
+	Iface string
+
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
 	done chan interface{}
 	lock sync.Mutex
@@ -417,6 +420,12 @@ func (p *Pinger) Run() error {
 		return err
 	}
 	defer conn.Close()
+
+	if p.Iface != "" {
+		if err = conn.BindToDevice(p.Iface); err != nil {
+			return err
+		}
+	}
 
 	conn.SetTTL(p.TTL)
 	return p.run(conn)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -1,6 +1,14 @@
-// +build linux
+//go:build linux
 
 package ping
+
+import (
+	"errors"
+	"reflect"
+	"syscall"
+
+	"golang.org/x/net/icmp"
+)
 
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
@@ -16,4 +24,34 @@ func (p *Pinger) matchID(ID int) bool {
 		}
 	}
 	return true
+}
+
+func getConnFD(conn *icmp.PacketConn) (fd int) {
+	var packetConn reflect.Value
+
+	defer func() {
+		if r := recover(); r != nil {
+			fd = -1
+		}
+	}()
+
+	if conn.IPv4PacketConn() != nil {
+		packetConn = reflect.ValueOf(conn.IPv4PacketConn().PacketConn)
+	} else if conn.IPv6PacketConn() != nil {
+		packetConn = reflect.ValueOf(conn.IPv6PacketConn().PacketConn)
+	} else {
+		return -1
+	}
+
+	netFD := reflect.Indirect(reflect.Indirect(packetConn).FieldByName("fd"))
+	pollFD := netFD.FieldByName("pfd")
+	systemFD := pollFD.FieldByName("Sysfd")
+	return int(systemFD.Int())
+}
+
+func (c *icmpConn) BindToDevice(ifName string) error {
+	if fd := getConnFD(c.c); fd >= 0 {
+		return syscall.BindToDevice(fd, ifName)
+	}
+	return errors.New("bind to interface unsupported")
 }

--- a/utils_other.go
+++ b/utils_other.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+//go:build !linux && !windows
 
 package ping
 
@@ -13,4 +13,8 @@ func (p *Pinger) matchID(ID int) bool {
 		return false
 	}
 	return true
+}
+
+func (c *icmpConn) BindToDevice(ifName string) error {
+	return errors.New("bind to interface unsupported")
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package ping
 
@@ -21,4 +21,8 @@ func (p *Pinger) matchID(ID int) bool {
 		return false
 	}
 	return true
+}
+
+func (c *icmpConn) BindToDevice(ifName string) error {
+	return errors.New("bind to interface unsupported")
 }


### PR DESCRIPTION
Hello,

I tried to implement useful feature - send packets from specific network interface. 
This feature is platform specific (depend on syscall.BindToDevice).
Hoping I did it correctly. Test successfully passed on Linux OS.

Thanks!