### PR TITLE
Report whether or not the TTL value was read

### DIFF
--- a/packetconn.go
+++ b/packetconn.go
@@ -65,7 +65,7 @@ func (c *icmpv4Conn) SetFlagTTL() error {
 }
 
 func (c *icmpv4Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
-	var ttl int
+	ttl := -1
 	n, cm, src, err := c.c.IPv4PacketConn().ReadFrom(b)
 	if cm != nil {
 		ttl = cm.TTL
@@ -90,7 +90,7 @@ func (c *icmpV6Conn) SetFlagTTL() error {
 }
 
 func (c *icmpV6Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
-	var ttl int
+	ttl := -1
 	n, cm, src, err := c.c.IPv6PacketConn().ReadFrom(b)
 	if cm != nil {
 		ttl = cm.HopLimit


### PR DESCRIPTION
In IPv6 a hop limit of 0 is valid, so the TTL the code is reporting is
actually a valid value in that case.

Initialize ttl to -1, so that in the case of not getting a TTL value
from the control message, we can let the rest of the code whether the
reported value was actually 0 or whether it couldn't be read.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>