### PR TITLE
Add support for handling lost packets

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -96,7 +96,7 @@ func New(addr string) *Pinger {
 		Size:              timeSliceLength + trackerLength,
 		Timeout:           time.Duration(math.MaxInt64),
 		addr:              addr,
-		done:              make(chan interface{}),
+		done:              make(chan struct{}),
 		id:                r.Intn(math.MaxUint16),
 		currentUUID:       uuid.New(),
 		ipaddr:            nil,
@@ -190,7 +190,7 @@ type Pinger struct {
 	Source string
 
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
-	done chan interface{}
+	done chan struct{}
 	lock sync.Mutex
 
 	ipaddr *net.IPAddr
@@ -549,13 +549,10 @@ func (p *Pinger) Stop() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	open := true
 	select {
-	case _, open = <-p.done:
+	case <-p.done:
+		return
 	default:
-	}
-
-	if open {
 		close(p.done)
 	}
 }

--- a/ping_test.go
+++ b/ping_test.go
@@ -37,7 +37,7 @@ func TestProcessPacket(t *testing.T) {
 		Seq:  pinger.sequence,
 		Data: data,
 	}
-	pinger.awaitingSequences[buildLookupKey(pinger.currentUUID, pinger.sequence)] = struct{}{}
+	pinger.awaitingSequences[buildLookupKey(pinger.currentUUID, pinger.sequence)] = time.Now()
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
@@ -458,7 +458,7 @@ func TestStatisticsLossy(t *testing.T) {
 	if stats.PacketsSent != 20 {
 		t.Errorf("Expected %v, got %v", 20, stats.PacketsSent)
 	}
-	if stats.PacketLoss != 50 {
+	if stats.PacketLoss != 0 {
 		t.Errorf("Expected %v, got %v", 50, stats.PacketLoss)
 	}
 	if stats.MinRtt != time.Duration(10) {
@@ -606,7 +606,7 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 		Data: data,
 	}
 	// register the sequence as sent
-	pinger.awaitingSequences[buildLookupKey(pinger.currentUUID, 0)] = struct{}{}
+	pinger.awaitingSequences[buildLookupKey(pinger.currentUUID, 0)] = time.Now()
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,

--- a/ping_test.go
+++ b/ping_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -492,46 +491,43 @@ func makeTestPinger() *Pinger {
 func AssertNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
-		t.Errorf("Expected No Error but got %s, Stack:\n%s",
-			err, string(debug.Stack()))
+		t.Errorf("Expected No Error but got %q", err)
 	}
 }
 
 func AssertError(t *testing.T, err error, info string) {
 	t.Helper()
 	if err == nil {
-		t.Errorf("Expected Error but got %s, %s, Stack:\n%s",
-			err, info, string(debug.Stack()))
+		t.Errorf("Expected Error %q but got %q",
+			err, info)
 	}
 }
 
 func AssertEqualStrings(t *testing.T, expected, actual string) {
 	t.Helper()
 	if expected != actual {
-		t.Errorf("Expected %s, got %s, Stack:\n%s",
-			expected, actual, string(debug.Stack()))
+		t.Errorf("Expected %s, got %s", expected, actual)
 	}
 }
 
 func AssertNotEqualStrings(t *testing.T, expected, actual string) {
 	t.Helper()
 	if expected == actual {
-		t.Errorf("Expected %s, got %s, Stack:\n%s",
-			expected, actual, string(debug.Stack()))
+		t.Errorf("Expected %q, got %q", expected, actual)
 	}
 }
 
 func AssertTrue(t *testing.T, b bool) {
 	t.Helper()
 	if !b {
-		t.Errorf("Expected True, got False, Stack:\n%s", string(debug.Stack()))
+		t.Errorf("Expected True, got False")
 	}
 }
 
 func AssertFalse(t *testing.T, b bool) {
 	t.Helper()
 	if b {
-		t.Errorf("Expected False, got True, Stack:\n%s", string(debug.Stack()))
+		t.Errorf("Expected False, got True")
 	}
 }
 


### PR DESCRIPTION
This MR adds functionality allowing to check whether ping packets are answered (in time). 
A regularly run check removes packets from the set of expected replies in case the timeout has been reached, increasing a `PacketsLost` counter and invoking an `OnLost` handler.

So far lost packets are simply computed by taking the delta of sent and received packets - which actually is not very precise.  E.g., computing this delta immediately after sending a packet will lead to a loss of > 0, although the packet should probably just be considered `still awaited` instead of `lost`.
Additionally, it was not possible to act based on the event of a package being (potentially) lost (by now being answered in time).

In order to implement this, the central `awaitingSequences` map has been flattened and now maps to a timestamp indicating the point in time a packet has been sent.
Flattening of the map brings the additional benefit of avoiding a continuous, monotonic growth of the map (which AFAICT happens so far because former UUID keys are not removed from the root map).
Additionally, that allowed removing the (also monotonically growing) list of previously used UUIDs.
IMHO this simplifies the codebase quite a bit as some edge cases are avoided.

A test covering the added functionality has been added, some small cleanups have been done aside (all isolated in their own commit) and the example `ping` app has been updated to showcase the new feature.

I will be glad to discuss these changes with you and adjust the MR accordingly if required.

