### PR TITLE
Goreleaser can no longer be installed using goreleaser.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 executors:
   golang:
     docker:
-    - image: cimg/go:1.15
+    - image: cimg/go:1.17
 
 version: 2.1
 jobs:
@@ -14,8 +14,12 @@ jobs:
       - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
       - run: golangci-lint run
       - run: make
-      - run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | BINDIR=/home/circleci/.local/bin sh
-      - run: goreleaser release --skip-publish --snapshot
+      - run: cd /tmp && curl -L --remote-name https://github.com/goreleaser/goreleaser/releases/download/v1.8.3/goreleaser_Linux_x86_64.tar.gz
+      - run: cd /tmp && curl -L --remote-name https://github.com/goreleaser/goreleaser/releases/download/v1.8.3/checksums.txt
+      - run: cd /tmp && sha256sum --ignore-missing -c checksums.txt
+      - run: mkdir -p /home/circleci/.local/bin
+      - run: tar -C /home/circleci/.local/bin -xf /tmp/goreleaser_Linux_x86_64.tar.gz goreleaser
+      - run: goreleaser release --skip-publish --snapshot --debug
       - store_artifacts:
           path: dist
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package ping

--- a/utils_other.go
+++ b/utils_other.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package ping

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package ping


### PR DESCRIPTION
This installation method was deprecated because the associated tool has
been deprecated.

Download "by hand" and run checks before trying to use binary.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>