### PR TITLE
Remove uses of Fatalf which causes the application to quit if a custom logger is provided such as Uber zap

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -481,8 +481,8 @@ func (p *Pinger) runLoop(
 		case r := <-recvCh:
 			err := p.processPacket(r)
 			if err != nil {
-				// FIXME: this logs as FATAL but continues
-				logger.Fatalf("processing received packet: %s", err)
+				// TODO: should this break the loop and return an error?
+				logger.Errorf("error processing received packet: %s", err)
 			}
 
 		case <-interval.C:
@@ -492,8 +492,8 @@ func (p *Pinger) runLoop(
 			}
 			err := p.sendICMP(conn)
 			if err != nil {
-				// FIXME: this logs as FATAL but continues
-				logger.Fatalf("sending packet: %s", err)
+				// TODO: should this break the loop and return an error?
+				logger.Errorf("error sending packet: %s", err)
 			}
 		}
 		if p.Count > 0 && p.PacketsRecv >= p.Count {


### PR DESCRIPTION
Uber zap's logger does `os.Exit()` if `Fatal()` or `Fatalf()` is called. Since go-ping supports custom loggers and in my case I pass in Uber zap's logger this causes my entire application to exit. Removing `Fatal()` calls is safer. If we need to ensure this error is handled up the call chain we can `panic()` which is better since the code can recover from a panic. The code cannot recover from an `os.Exit()` call.