### PR TITLE
Fix non-privileged (UDP) ping response parsing for OSes not supporting STRIPHDR sock option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /ping
 /dist
+.idea

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -3,9 +3,20 @@
 
 package ping
 
+import (
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
-	return p.Size + 8
+	if p.Privileged() {
+		return p.Size + 8
+	}
+	if p.ipv4 {
+		return p.Size + 8 + ipv4.HeaderLen
+	}
+	return p.Size + 8 + ipv6.HeaderLen
 }
 
 // Attempts to match the ID of an ICMP packet.

--- a/utils_other.go
+++ b/utils_other.go
@@ -3,9 +3,20 @@
 
 package ping
 
+import (
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
-	return p.Size + 8
+	if p.Privileged() {
+		return p.Size + 8
+	}
+	if p.ipv4 {
+		return p.Size + 8 + ipv4.HeaderLen
+	}
+	return p.Size + 8 + ipv6.HeaderLen
 }
 
 // Attempts to match the ID of an ICMP packet.


### PR DESCRIPTION

It could be related to the issues #180 & #216. I noticed that on Mac OS 12.5, MacBook Pro M1 non-privileged pings do not work on remote IPs (pinging local loopback interfaces works fine). 
While I can see correct  ICMP requests & responses with tcpdump, ping discards responses because they include  unexpected IP headers.

It looks like STRIPHDR socket option is not working as expected on some darwin setups: https://go.googlesource.com/net/+/master/icmp/listen_posix.go#75.

The workaround fixes the issue on Mac & doesn't break working loopback pings, but it wasn't tested on Windows or linux.



