### PR TITLE
Add packet timeout option and make latency more accurate

### DIFF
--- a/ping_test.go
+++ b/ping_test.go
@@ -28,7 +28,7 @@ func TestProcessPacket(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), uuidEncoded...)
+	data := append(TimestampToBytes(), uuidEncoded...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -71,7 +71,7 @@ func TestProcessPacket_IgnoreNonEchoReplies(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), currentUUID...)
+	data := append(TimestampToBytes(), currentUUID...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -114,7 +114,7 @@ func TestProcessPacket_IDMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), currentUUID...)
+	data := append(TimestampToBytes(), currentUUID...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -156,7 +156,7 @@ func TestProcessPacket_TrackerMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), testUUID...)
+	data := append(TimestampToBytes(), testUUID...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -194,7 +194,7 @@ func TestProcessPacket_LargePacket(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), currentUUID...)
+	data := append(TimestampToBytes(), currentUUID...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -547,7 +547,7 @@ func BenchmarkProcessPacket(b *testing.B) {
 	if err != nil {
 		b.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), currentUUID...)
+	data := append(TimestampToBytes(), currentUUID...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -597,7 +597,7 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("unable to marshal UUID binary: %s", err))
 	}
-	data := append(timeToBytes(time.Now()), uuidEncoded...)
+	data := append(TimestampToBytes(), uuidEncoded...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}

--- a/ping_test.go
+++ b/ping_test.go
@@ -38,7 +38,7 @@ func TestProcessPacket(t *testing.T) {
 		Seq:  pinger.sequence,
 		Data: data,
 	}
-	pinger.awaitingSequences[currentUUID][pinger.sequence] = struct{}{}
+	pinger.awaitingSequences[currentUUID][pinger.sequence] = currentTimestamp()
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
@@ -608,7 +608,7 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 		Data: data,
 	}
 	// register the sequence as sent
-	pinger.awaitingSequences[currentUUID][0] = struct{}{}
+	pinger.awaitingSequences[currentUUID][0] = currentTimestamp()
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -3,6 +3,15 @@
 
 package ping
 
+import (
+	"strconv"
+	"time"
+)
+
+var (
+	basetime = time.Now()
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
 	return p.Size + 8
@@ -17,4 +26,41 @@ func (p *Pinger) matchID(ID int) bool {
 		}
 	}
 	return true
+}
+
+// Convert a duration to a byte array
+func durationToBytes(d time.Duration) []byte {
+	nsec := d.Nanoseconds()
+	b := make([]byte, 8)
+	for i := uint8(0); i < 8; i++ {
+		b[i] = byte((nsec >> ((7 - i) * 8)) & 0xff)
+	}
+	return b
+}
+
+// Convert a byte array to a duration
+func bytesToDuration(b []byte) time.Duration {
+	var nsec int64
+	var t time.Duration
+	for i := uint8(0); i < 8; i++ {
+		nsec += int64(b[i]) << ((7 - i) * 8)
+	}
+	nstring := strconv.FormatInt(nsec, 10) + "ns"
+	t, _ = time.ParseDuration(nstring)
+	return t
+}
+
+// Convert a bytes array encoding duration to a number of Nanoseconds
+func BytesToTimestamp(data []byte) uint64 {
+	return uint64(bytesToDuration(data).Nanoseconds())
+}
+
+// Convert a number of nanoseconds to a byte array endoded duration
+func TimestampToBytes() []byte {
+	return durationToBytes(time.Since(basetime))
+}
+
+// Return current number of nanoseconds since basetime (as it is a duration it cannot/mustn't be negative)
+func currentTimestamp() uint64 {
+	return uint64(time.Since(basetime).Nanoseconds())
 }

--- a/utils_other.go
+++ b/utils_other.go
@@ -3,6 +3,15 @@
 
 package ping
 
+import (
+	"time"
+	"strconv"
+)
+
+var (
+	basetime = time.Now()
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
 	return p.Size + 8
@@ -14,4 +23,41 @@ func (p *Pinger) matchID(ID int) bool {
 		return false
 	}
 	return true
+}
+
+// Convert a duration to a byte array
+func durationToBytes(d time.Duration) []byte {
+	nsec := d.Nanoseconds()
+	b := make([]byte, 8)
+	for i := uint8(0); i < 8; i++ {
+		b[i] = byte((nsec >> ((7 - i) * 8)) & 0xff)
+	}
+	return b
+}
+
+// Convert a byte array to a duration
+func bytesToDuration(b []byte) time.Duration {
+	var nsec int64
+	var t time.Duration
+	for i := uint8(0); i < 8; i++ {
+		nsec += int64(b[i]) << ((7 - i) * 8)
+	}
+	nstring := strconv.FormatInt(nsec, 10) + "ns"
+	t, _ = time.ParseDuration(nstring)
+	return t
+}
+
+// Convert a bytes array encoding duration to a number of Nanoseconds
+func BytesToTimestamp(data []byte) uint64 {
+	return uint64(bytesToDuration(data).Nanoseconds())
+}
+
+// Convert a number of nanoseconds to a byte array endoded duration
+func TimestampToBytes() []byte {
+	return durationToBytes(time.Since(basetime).Nanoseconds()))
+}
+
+// Return current number of nanoseconds since basetime (as it is a duration it cannot/mustn't be negative)
+func currentTimestamp() uint64 {
+	return uint64(time.Since(basetime).Nanoseconds())
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -4,8 +4,20 @@
 package ping
 
 import (
+	"strconv"
+	"syscall"
+	"time"
+	"unsafe"
+
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+)
+
+var (
+	modkernel32                = syscall.NewLazyDLL("kernel32.dll")
+	_QueryPerformanceFrequency = modkernel32.NewProc("QueryPerformanceFrequency")
+	_QueryPerformanceCounter   = modkernel32.NewProc("QueryPerformanceCounter")
+	cpufreq                    = QPCFrequency()
 )
 
 // Returns the length of an ICMP message, plus the IP packet header.
@@ -22,4 +34,63 @@ func (p *Pinger) matchID(ID int) bool {
 		return false
 	}
 	return true
+}
+
+// Returns an int64 of the number of ticks since start using queryPerformanceCounter
+func QPC() uint64 {
+	var now uint64
+	r1, _, _ := syscall.SyscallN(_QueryPerformanceCounter.Addr(), uintptr(unsafe.Pointer(&now)))
+	if r1 == 0 {
+		panic("call failed")
+	}
+	return now
+}
+
+// QPCFrequency returns frequency in ticks per second
+func QPCFrequency() uint64 {
+	var freq uint64
+	r1, _, _ := syscall.SyscallN(_QueryPerformanceFrequency.Addr(), uintptr(unsafe.Pointer(&freq)))
+	if r1 == 0 {
+		panic("call failed")
+	}
+	return freq
+}
+
+// Get duration of a CPU cycle (tick)
+func GetTickDuration() time.Duration {
+	out, _ := time.ParseDuration(strconv.FormatUint(uint64(time.Second.Nanoseconds())/QPCFrequency(), 10) + "ns")
+	return out
+}
+
+// Convert a number of ticks to a byte array encoded duration
+func QpcToBytes(nticks uint64) []byte {
+	b := make([]byte, 8)
+	for i := uint8(0); i < 8; i++ {
+		b[i] = byte((nticks >> ((7 - i) * 8)) & 0xff)
+	}
+	return b
+}
+
+// Convert a byte array encoded duration to a number of ticks
+func bytesToQpc(b []byte) uint64 {
+	var nticks uint64
+	for i := uint8(0); i < 8; i++ {
+		nticks += uint64(b[i]) << ((7 - i) * 8)
+	}
+	return nticks
+}
+
+// Convert a bytes array encoding duration to a number of Nanoseconds
+func BytesToTimestamp(data []byte) uint64 {
+	return bytesToQpc(data)
+}
+
+// Convert a number of nanoseconds to a byte array endoded duration
+func TimestampToBytes() []byte {
+	return QpcToBytes(currentTimestamp())
+}
+
+// Return current number of nanoseconds since basetime (as it is a duration it cannot/mustn't be negative)
+func currentTimestamp() uint64 {
+	return QPC() * uint64(time.Second.Nanoseconds()) / cpufreq
 }


### PR DESCRIPTION
Two major improvements :
- Add packet timeout option
- Improve ping rtt time accuracy on windows (to be able to go under millisecond)

Small improvement : 
- Use program side time object instead of storing datetime on the packet body to get ping packet rtt. It avoids bad timing while clock is changing (for DST or on NTP sync, for example) ref : https://github.com/golang/go/issues/12914