### PR TITLE
fix: Non-privileged (UDP) ping response parsing for OSes not supporting STRIPHDR sock option

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -3,9 +3,22 @@
 
 package ping
 
+import (
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
-	return p.Size + 8
+	if p.Privileged() {
+		return p.Size + 8
+	}
+
+	if p.ipv4 {
+		return p.Size + 8 + ipv4.HeaderLen
+	}
+
+	return p.Size + 8 + ipv6.HeaderLen
 }
 
 // Attempts to match the ID of an ICMP packet.

--- a/utils_other.go
+++ b/utils_other.go
@@ -3,9 +3,22 @@
 
 package ping
 
+import (
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
-	return p.Size + 8
+	if p.Privileged() {
+		return p.Size + 8
+	}
+
+	if p.ipv4 {
+		return p.Size + 8 + ipv4.HeaderLen
+	}
+
+	return p.Size + 8 + ipv6.HeaderLen
 }
 
 // Attempts to match the ID of an ICMP packet.


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

Refer to https://github.com/go-ping/ping/pull/218.