### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Deprecated
+
+Due to lack of maintainers and access, this library is no longer maintained.
+There is a new actively maintained fork: https://github.com/prometheus-community/pro-bing
+
 # go-ping
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/go-ping/ping)](https://pkg.go.dev/github.com/go-ping/ping)
 [![Circle CI](https://circleci.com/gh/go-ping/ping.svg?style=svg)](https://circleci.com/gh/go-ping/ping)


### PR DESCRIPTION
As mentioned in #221 and https://github.com/influxdata/telegraf/pull/11836#issuecomment-1254213986, add a notice to the project's README to inform users.

closes #221