### PR TITLE
Set interface name, like `ping -I` option(#111 #204)

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -13,7 +13,7 @@ import (
 var usage = `
 Usage:
 
-    ping [-c count] [-i interval] [-t timeout] [--privileged] host
+    ping [-c count] [-i interval] [-t timeout] [-I interface] [--privileged] host
 
 Examples:
 
@@ -29,6 +29,10 @@ Examples:
     # ping google for 10 seconds
     ping -t 10s www.google.com
 
+    # ping google specified interface
+    ping -I eth1 www.goole.com
+    ping -I eth2 www.goole.com
+
     # Send a privileged raw ICMP ping
     sudo ping --privileged www.google.com
 
@@ -42,6 +46,7 @@ func main() {
 	count := flag.Int("c", -1, "")
 	size := flag.Int("s", 24, "")
 	ttl := flag.Int("l", 64, "TTL")
+	iface := flag.String("I", "", "interface name")
 	privileged := flag.Bool("privileged", false, "")
 	flag.Usage = func() {
 		fmt.Print(usage)
@@ -90,6 +95,7 @@ func main() {
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
 	pinger.TTL = *ttl
+	pinger.Iface = *iface
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())

--- a/packetconn.go
+++ b/packetconn.go
@@ -18,11 +18,13 @@ type packetConn interface {
 	SetReadDeadline(t time.Time) error
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	SetTTL(ttl int)
+	SetIfaceIndex(iface string)
 }
 
 type icmpConn struct {
-	c   *icmp.PacketConn
-	ttl int
+	c          *icmp.PacketConn
+	ttl        int
+	ifaceIndex int
 }
 
 func (c *icmpConn) Close() error {
@@ -33,23 +35,16 @@ func (c *icmpConn) SetTTL(ttl int) {
 	c.ttl = ttl
 }
 
-func (c *icmpConn) SetReadDeadline(t time.Time) error {
-	return c.c.SetReadDeadline(t)
+func (c *icmpConn) SetIfaceIndex(iface string) {
+	i, err := net.InterfaceByName(iface)
+	if err != nil {
+		c.ifaceIndex = 0
+	}
+	c.ifaceIndex = i.Index
 }
 
-func (c *icmpConn) WriteTo(b []byte, dst net.Addr) (int, error) {
-	if c.c.IPv6PacketConn() != nil {
-		if err := c.c.IPv6PacketConn().SetHopLimit(c.ttl); err != nil {
-			return 0, err
-		}
-	}
-	if c.c.IPv4PacketConn() != nil {
-		if err := c.c.IPv4PacketConn().SetTTL(c.ttl); err != nil {
-			return 0, err
-		}
-	}
-
-	return c.c.WriteTo(b, dst)
+func (c *icmpConn) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
 }
 
 type icmpv4Conn struct {
@@ -77,6 +72,22 @@ func (c icmpv4Conn) ICMPRequestType() icmp.Type {
 	return ipv4.ICMPTypeEcho
 }
 
+func (c *icmpv4Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if err := c.c.IPv4PacketConn().SetTTL(c.ttl); err != nil {
+		return 0, err
+	}
+	var cm *ipv4.ControlMessage
+	if 1 <= c.ifaceIndex {
+		// set interface
+		if err := c.c.IPv4PacketConn().SetControlMessage(ipv4.FlagInterface, true); err != nil {
+			return 0, err
+		}
+		cm = &ipv4.ControlMessage{IfIndex: c.ifaceIndex}
+	}
+
+	return c.c.IPv4PacketConn().WriteTo(b, cm, dst)
+}
+
 type icmpV6Conn struct {
 	icmpConn
 }
@@ -100,4 +111,20 @@ func (c *icmpV6Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
 
 func (c icmpV6Conn) ICMPRequestType() icmp.Type {
 	return ipv6.ICMPTypeEchoRequest
+}
+
+func (c *icmpV6Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if err := c.c.IPv6PacketConn().SetHopLimit(c.ttl); err != nil {
+		return 0, err
+	}
+	var cm *ipv6.ControlMessage
+	if 1 <= c.ifaceIndex {
+		// set interface
+		if err := c.c.IPv6PacketConn().SetControlMessage(ipv6.FlagInterface, true); err != nil {
+			return 0, err
+		}
+		cm = &ipv6.ControlMessage{IfIndex: c.ifaceIndex}
+	}
+
+	return c.c.IPv6PacketConn().WriteTo(b, cm, dst)
 }

--- a/packetconn.go
+++ b/packetconn.go
@@ -18,7 +18,7 @@ type packetConn interface {
 	SetReadDeadline(t time.Time) error
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	SetTTL(ttl int)
-	SetIfaceIndex(iface string)
+	SetIfaceIndex(ifaceIndex int)
 }
 
 type icmpConn struct {
@@ -35,12 +35,8 @@ func (c *icmpConn) SetTTL(ttl int) {
 	c.ttl = ttl
 }
 
-func (c *icmpConn) SetIfaceIndex(iface string) {
-	i, err := net.InterfaceByName(iface)
-	if err != nil {
-		c.ifaceIndex = 0
-	}
-	c.ifaceIndex = i.Index
+func (c *icmpConn) SetIfaceIndex(ifaceIndex int) {
+	c.ifaceIndex = ifaceIndex
 }
 
 func (c *icmpConn) SetReadDeadline(t time.Time) error {
@@ -78,7 +74,7 @@ func (c *icmpv4Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
 	}
 	var cm *ipv4.ControlMessage
 	if 1 <= c.ifaceIndex {
-		// set interface
+		// If not set interface c.ifaceIndex == 0
 		if err := c.c.IPv4PacketConn().SetControlMessage(ipv4.FlagInterface, true); err != nil {
 			return 0, err
 		}
@@ -119,7 +115,7 @@ func (c *icmpV6Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
 	}
 	var cm *ipv6.ControlMessage
 	if 1 <= c.ifaceIndex {
-		// set interface
+		// If not set interface c.ifaceIndex == 0
 		if err := c.c.IPv6PacketConn().SetControlMessage(ipv6.FlagInterface, true); err != nil {
 			return 0, err
 		}

--- a/ping.go
+++ b/ping.go
@@ -49,7 +49,6 @@
 // it calls the OnFinish callback.
 //
 // For a full ping example, see "cmd/ping/ping.go".
-//
 package ping
 
 import (
@@ -181,6 +180,9 @@ type Pinger struct {
 
 	// Source is the source IP address
 	Source string
+
+	// Iface used to send/recv ICMP messages
+	Iface string
 
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
 	done chan interface{}
@@ -419,6 +421,9 @@ func (p *Pinger) Run() error {
 	defer conn.Close()
 
 	conn.SetTTL(p.TTL)
+	if p.Iface != "" {
+		conn.SetIfaceIndex(p.Iface)
+	}
 	return p.run(conn)
 }
 

--- a/ping.go
+++ b/ping.go
@@ -422,7 +422,11 @@ func (p *Pinger) Run() error {
 
 	conn.SetTTL(p.TTL)
 	if p.Iface != "" {
-		conn.SetIfaceIndex(p.Iface)
+		iface, err := net.InterfaceByName(p.Iface)
+		if err != nil {
+			return err
+		}
+		conn.SetIfaceIndex(iface.Index)
 	}
 	return p.run(conn)
 }

--- a/ping_test.go
+++ b/ping_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"runtime"
 	"runtime/debug"
 	"sync/atomic"
 	"testing"
@@ -474,6 +475,25 @@ func TestStatisticsLossy(t *testing.T) {
 	if stats.StdDevRtt != time.Duration(29603) {
 		t.Errorf("Expected %v, got %v", time.Duration(29603), stats.StdDevRtt)
 	}
+}
+
+func TestSetIfaceName(t *testing.T) {
+	pinger := New("www.google.com")
+	pinger.Count = 1
+
+	// Set loopback interface
+	pinger.Iface = "lo"
+	err := pinger.Run()
+	if runtime.GOOS == "linux" {
+		AssertNoError(t, err)
+	} else {
+		AssertError(t, err, "other platforms unsupport this feature")
+	}
+
+	// Set fake interface
+	pinger.Iface = "L()0pB@cK"
+	err = pinger.Run()
+	AssertError(t, err, "device not found")
 }
 
 // Test helpers

--- a/ping_test.go
+++ b/ping_test.go
@@ -642,6 +642,7 @@ func (c testPacketConn) ICMPRequestType() icmp.Type        { return ipv4.ICMPTyp
 func (c testPacketConn) SetFlagTTL() error                 { return nil }
 func (c testPacketConn) SetReadDeadline(t time.Time) error { return nil }
 func (c testPacketConn) SetTTL(t int)                      {}
+func (c testPacketConn) SetIfaceIndex(iface string)        {}
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
 	return 0, 0, nil, nil

--- a/ping_test.go
+++ b/ping_test.go
@@ -480,6 +480,8 @@ func TestStatisticsLossy(t *testing.T) {
 func TestSetIfaceName(t *testing.T) {
 	pinger := New("www.google.com")
 	pinger.Count = 1
+	pinger.Timeout = time.Second
+	pinger.SetPrivileged(true)
 
 	// Set loopback interface
 	pinger.Iface = "lo"
@@ -662,7 +664,7 @@ func (c testPacketConn) ICMPRequestType() icmp.Type        { return ipv4.ICMPTyp
 func (c testPacketConn) SetFlagTTL() error                 { return nil }
 func (c testPacketConn) SetReadDeadline(t time.Time) error { return nil }
 func (c testPacketConn) SetTTL(t int)                      {}
-func (c testPacketConn) SetIfaceIndex(iface string)        {}
+func (c testPacketConn) SetIfaceIndex(ifaceIndex int)      {}
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
 	return 0, 0, nil, nil


### PR DESCRIPTION
Hello,

I attempted to implement a useful feature - sending data packets from a specific network interface, similar to what the "ping" command's "-I" option does in Linux.
Hoping I did it correctly. Test successfully passed on Linux OS.

Thanks!