### PR TITLE
Mark module as deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,3 +4,7 @@ issues:
   - path: _test.go
     linters:
     - errcheck
+linters-settings:
+  staticcheck:
+    checks:
+      - "-SA1019"

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -1,3 +1,4 @@
+// Deprecated: This package is no longer maintained.
 package main
 
 import (

--- a/ping.go
+++ b/ping.go
@@ -1,4 +1,5 @@
 // Deprecated: This package is no longer maintained.
+// Package ping is a simple but powerful ICMP echo (ping) library.
 //
 // Here is a very simple example that sends and receives three packets:
 //

--- a/ping.go
+++ b/ping.go
@@ -1,4 +1,3 @@
-// Deprecated: This package is no longer maintained.
 // Package ping is a simple but powerful ICMP echo (ping) library.
 //
 // Here is a very simple example that sends and receives three packets:
@@ -51,6 +50,7 @@
 //
 // For a full ping example, see "cmd/ping/ping.go".
 //
+// Deprecated: This package is no longer maintained.
 package ping
 
 import (

--- a/ping.go
+++ b/ping.go
@@ -1,4 +1,4 @@
-// Package ping is a simple but powerful ICMP echo (ping) library.
+// Deprecated: This package is no longer maintained.
 //
 // Here is a very simple example that sends and receives three packets:
 //

--- a/ping.go
+++ b/ping.go
@@ -1,5 +1,7 @@
 // Package ping is a simple but powerful ICMP echo (ping) library.
 //
+// Deprecated: This package is no longer maintained.
+//
 // Here is a very simple example that sends and receives three packets:
 //
 //	pinger, err := ping.NewPinger("www.google.com")
@@ -50,7 +52,6 @@
 //
 // For a full ping example, see "cmd/ping/ping.go".
 //
-// Deprecated: This package is no longer maintained.
 package ping
 
 import (


### PR DESCRIPTION
In addition to #226, also mark the Go package as deprecated.